### PR TITLE
fix broken dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Kusto language plugin for the Monaco Editor. It provides the following features 
 ```
 
 ## Changelog
+### 1.0.10 (7/1/2019)
+#### Bug fix
+- Fix broken dependency on language service.
 ### 1.0.9 (7/1/2019)
 #### Bug fix
 - don't suggest chart types that we do not support yet.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -62,9 +62,9 @@
       }
     },
     "@kusto/language-service": {
-      "version": "0.0.23-alpha",
-      "resolved": "https://registry.npmjs.org/@kusto/language-service/-/language-service-0.0.23-alpha.tgz",
-      "integrity": "sha512-z/dk+D2HzhPhafYwPBc7YSluzxYNs/a4F+xywK+G94HW3QQ9cZIEttJJG9yw8KaQ/kbckMYy5zGWx5EtpN/NWQ=="
+      "version": "0.0.29-rc.1",
+      "resolved": "https://registry.npmjs.org/@kusto/language-service/-/language-service-0.0.29-rc.1.tgz",
+      "integrity": "sha512-I3Pf0053RGES9O+YMYxLxi70P+Ijzb92RPMqHH0X+HIOA2/2vvQ/46gpbToryv8+WurSISxh9uNS/O8jw9t4RA=="
     },
     "@kusto/language-service-next": {
       "version": "0.0.28-rc.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "CSL, KQL plugin for the Monaco Editor",
   "author": {
     "name": "Microsoft"
@@ -48,7 +48,7 @@
     "xregexp": "^3.2.0"
   },
   "dependencies": {
-    "@kusto/language-service": "0.0.23-alpha",
+    "@kusto/language-service": "0.0.29-rc.1",
     "@kusto/language-service-next": "0.0.28-rc.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Summary

We had an npm package out with changes unmerged to master. This caused following commits to revert the package back to old language service dependencies.