### PR TITLE
add getQueryParams to language service

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Kusto language plugin for the Monaco Editor. It provides the following features 
 ```
 
 ## Changelog
+### 1.1.15 (10/25/2019)
+#### Added
+- Introduce a new function in language service called `getQueryParams`. it will return an array of all delcared query parameters for the query on cursor.
 ### 1.1.14 (9/16/2019)
 #### Bug fix
 - Fix 1.1.13 to return ranges based on 1 (as monaco expects) rather than 0 (as kusto language server returns).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "CSL, KQL plugin for the Monaco Editor",
   "author": {
     "name": "Microsoft"

--- a/src/kustoWorker.ts
+++ b/src/kustoWorker.ts
@@ -56,6 +56,21 @@ export class KustoWorker {
 		return commandInContext;
 	}
 
+	getQueryParams(uri: string, cursorOffest: number): Promise<{name: string, type: string}[]> {
+		const document = this._getTextDocument(uri);
+		if (!document) {
+			console.error(`getQueryParams: document is ${document}. uri is ${uri}`);
+			return null;
+		}
+
+		const queryParams = this._languageService.getQueryParams(document, cursorOffest);
+		if (queryParams === undefined) {
+			return null;
+		}
+
+		return queryParams;
+	}
+
 	/**
 	 * Get command in cotext and the command range.
 	 * This method will basically convert generate microsoft language service interface to monaco interface.

--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -49,6 +49,7 @@ declare module monaco.languages.kusto {
 		getCommandsInDocument(uri: string): Promise<{absoluteStart: number, absoluteEnd: number, text: string}[]>;
 		getClientDirective(text: string): Promise<{isClientDirective: boolean, directiveWithoutLeadingComments: string}>;
 		getAdminCommand(text: string): Promise<{isAdminCommand: boolean, adminCommandWithoutLeadingComments: string}>;
+		getQueryParams(uri: string, cursorOffest: number): Promise<{name: string, type: string}[];
 	}
 
 	/**

--- a/test/index.html
+++ b/test/index.html
@@ -31,6 +31,7 @@
 
 <script>
 	var getCurrentCommand;
+	var getQueryParams;
 	var setDM;
 	var setHelp;
 	var setKuskus;
@@ -64,6 +65,16 @@
 				})
 			});
 		})};
+		getQueryParams = () => {
+			monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+			const model = editor.getModel();
+			workerAccessor(model.uri).then(worker => {
+				worker.getQueryParams(model.uri.toString(), model.getOffsetAt(editor.getPosition())).then(queryParams => {
+					currentCommand.innerHTML = JSON.stringify(queryParams);
+				})
+			});
+		});
+		}
 
 		setDM = () => {
 			monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
@@ -297,6 +308,9 @@
 </div>
 <div>
 	<button onclick="getCurrentCommand()">Show current Command and position</button>
+</div>
+<div>
+	<button onclick="getQueryParams()">Show current query params</button>
 </div>
 <div id="currentCommand">
 


### PR DESCRIPTION
### Summary
added an ability to get all declared query parameters for the query in current offset.
a query that has query parameters statement looks like:

````KQL
declare query_parameters (x: string, y: int);
T | where x == "East US" `
````

the function will return the name and type of each query parameter.

in order to test:
1. npm i
2. ./test/index.html
3. write a query that has query parameters
4. click the `show query params` button.