### PR TITLE
add getGlobalParams to langauge service

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,17 @@ Kusto language plugin for the Monaco Editor. It provides the following features 
 
 ## Changelog
 
+### 1.1.18 (11/18/2019)
+
+#### Added
+
+-   Abiltiy to get global parameters in scope (getGlobalParams)).
+
 ### 1.1.17 (11/14/2019)
 
 #### Added
 
--   Ability to injet global parameters to intellisense
+-   Ability to injet global parameters to intellisense (in setSchema)
 
 ### 1.1.16 (10/28/2019)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "1.0.16",
+  "version": "1.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "1.0.17",
+    "version": "1.0.18",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/src/kustoWorker.ts
+++ b/src/kustoWorker.ts
@@ -70,6 +70,21 @@ export class KustoWorker {
         return queryParams;
     }
 
+    getGlobalParams(uri: string): Promise<{ name: string; type: string }[]> {
+        const document = this._getTextDocument(uri);
+        if (!document) {
+            console.error(`getGLobalParams: document is ${document}. uri is ${uri}`);
+            return null;
+        }
+
+        const globalParams = this._languageService.getGlobalParams(document);
+        if (globalParams === undefined) {
+            return null;
+        }
+
+        return globalParams;
+    }
+
     /**
      * Get command in cotext and the command range.
      * This method will basically convert generate microsoft language service interface to monaco interface.

--- a/src/languageService/kustoLanguageService.ts
+++ b/src/languageService/kustoLanguageService.ts
@@ -114,6 +114,7 @@ export interface LanguageService {
     findDefinition(document: ls.TextDocument, position: ls.Position): Promise<ls.Location[]>;
     findReferences(document: ls.TextDocument, position: ls.Position): Promise<ls.Location[]>;
     getQueryParams(document: ls.TextDocument, cursorOffset: number): Promise<{name: string, type: string}[]>;
+    getGlobalParams(document: ls.TextDocument): Promise<{name: string, type: string}[]>;
 }
 
 export interface LanguageSettings {
@@ -821,6 +822,17 @@ export type CmSchema = {
         });
 
         return Promise.as(queryParams);
+    }
+
+    getGlobalParams(document: ls.TextDocument): Promise<{name: string, type: string}[]> {
+        if (!this._languageSettings.useIntellisenseV2) {
+            return Promise.as([]);
+        }
+
+        const script = this.parseDocumentV2(document);
+        const params = this.toArray<sym.ParameterSymbol>(this._kustoJsSchemaV2.Parameters);
+        const result = params.map(param => ({name: param.Name, type: param.Type.Name}));
+        return Promise.as(result);
     }
 
     doRename(document: ls.TextDocument, position: ls.Position, newName: string): Promise<ls.WorkspaceEdit | undefined> {

--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -64,6 +64,7 @@ declare module monaco.languages.kusto {
         ): Promise<{ isClientDirective: boolean; directiveWithoutLeadingComments: string }>;
         getAdminCommand(text: string): Promise<{ isAdminCommand: boolean; adminCommandWithoutLeadingComments: string }>;
         getQueryParams(uri: string, cursorOffest: number): Promise<{ name: string; type: string }[]>;
+        getGlobalParams(uri: string): Promise<{ name: string; type: string }[]>;
     }
 
     /**

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,10 +1,11 @@
 {
-  "compilerOptions": {
-    "module": "umd",
-    "moduleResolution": "node",
-    "outDir": "../out",
-    "target": "es5",
-    "alwaysStrict": true,
-    "declaration": true
-  }
+    "compilerOptions": {
+        "module": "umd",
+        "moduleResolution": "node",
+        "outDir": "../out",
+        "target": "es5",
+        "alwaysStrict": true,
+        "declaration": true,
+        "skipLibCheck": true
+    }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -33,6 +33,7 @@
 	var setHelpWithParameter;
 	var getCurrentCommand;
 	var getQueryParams;
+	var getGlobalParams;
 	var setDM;
 	var setHelp;
 	var setKuskus;
@@ -70,6 +71,17 @@
 			const model = editor.getModel();
 			workerAccessor(model.uri).then(worker => {
 				worker.getQueryParams(model.uri.toString(), model.getOffsetAt(editor.getPosition())).then(queryParams => {
+					currentCommand.innerHTML = JSON.stringify(queryParams);
+				})
+			});
+		});
+		}
+
+		getGlobalParams = () => {
+			monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+			const model = editor.getModel();
+			workerAccessor(model.uri).then(worker => {
+				worker.getGlobalParams(model.uri.toString()).then(queryParams => {
 					currentCommand.innerHTML = JSON.stringify(queryParams);
 				})
 			});
@@ -318,6 +330,7 @@
 </div>
 <div>
 	<button onclick="getQueryParams()">Show current query params</button>
+	<button onclick="getGlobalParams()">Show current global params</button>
 </div>
 <div id="currentCommand">
 


### PR DESCRIPTION
### Summary
This change introduces a getGlobalParams method that will return the list of global parameters curretnyl declared in global scope.
 <!--

 Link to the issue describing the bug that you're fixing.

 Provide a general description of the code changes in your pull request.

 -->

 ### Other Information

 <!--

 If there's anything else that's important and relevant to your pull request, mention that information here.

 -->