### PR TITLE
added getReferencedGloablParameters method to worker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Kusto language plugin for the Monaco Editor. It provides the following features 
 
 ## Changelog
 
+### 2.0.4
+#### Added
+- Added `getReferencedGlobalParams` that returns the global (ambient) parameters that are actually being referenced in the query.
+
 ### 2.0.3
 
 #### Bug fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/src/kustoWorker.ts
+++ b/src/kustoWorker.ts
@@ -85,6 +85,21 @@ export class KustoWorker {
         return globalParams;
     }
 
+    getReferencedGlobalParams(uri: string, cursorOffest: number): Promise<{ name: string; type: string }[]> {
+        const document = this._getTextDocument(uri);
+        if (!document) {
+            console.error(`getReferencedGlobalParams: document is ${document}. uri is ${uri}`);
+            return null;
+        }
+
+        const referencedParams = this._languageService.getReferencedGlobalParams(document, cursorOffest);
+        if (referencedParams === undefined) {
+            return null;
+        }
+
+        return referencedParams;
+    }
+
     /**
      * Get command in cotext and the command range.
      * This method will basically convert generate microsoft language service interface to monaco interface.

--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -63,8 +63,28 @@ declare module monaco.languages.kusto {
             text: string
         ): Promise<{ isClientDirective: boolean; directiveWithoutLeadingComments: string }>;
         getAdminCommand(text: string): Promise<{ isAdminCommand: boolean; adminCommandWithoutLeadingComments: string }>;
+
+        /**
+         * Get all declared query parameters declared in current block if any.
+         */
         getQueryParams(uri: string, cursorOffest: number): Promise<{ name: string; type: string }[]>;
+
+        /**
+         * Get all the ambient parameters defind in global scope.
+         * Ambient parameters are parameters that are not defined in the syntax such as in a query paramter declaration.
+         * These are parameters that are injected from outside, usually by a UX application that would like to offer
+         * the user intellisense for a symbol, without forcing them to write a query declaration statement.
+         * Usually  the same application injects the query declaration statement and the parameter values when
+         * executing the query (so it will execute correctly)
+         */
         getGlobalParams(uri: string): Promise<{ name: string; type: string }[]>;
+        /**
+         * Get the global parameters that are actually being referenced in query.
+         * This is different from getQueryParams that will return the parameters declare using a query declaration
+         * statement.
+         * It is also different from getGlobalParams that will return all global parameters whether used or not.
+         */
+        getReferencedGlobalParams(uri: string): Promise<{ name: string; type: string }[]>;
     }
 
     /**

--- a/test/index.html
+++ b/test/index.html
@@ -34,6 +34,7 @@
 	var getCurrentCommand;
 	var getQueryParams;
 	var getGlobalParams;
+	var getReferencedGlobalParams;
 	var setDM;
 	var setHelp;
 	var setKuskus;
@@ -83,6 +84,17 @@
 			workerAccessor(model.uri).then(worker => {
 				worker.getGlobalParams(model.uri.toString()).then(queryParams => {
 					currentCommand.innerHTML = JSON.stringify(queryParams);
+				})
+			});
+		});
+		}
+
+		getReferencedGlobalParams = () => {
+			monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+			const model = editor.getModel();
+			workerAccessor(model.uri).then(worker => {
+				worker.getReferencedGlobalParams(model.uri.toString(), model.getOffsetAt(editor.getPosition())).then(referencedParams => {
+					currentCommand.innerHTML = JSON.stringify(referencedParams);
 				})
 			});
 		});
@@ -330,7 +342,8 @@
 </div>
 <div>
 	<button onclick="getQueryParams()">Show current query params</button>
-	<button onclick="getGlobalParams()">Show current global params</button>
+	<button onclick="getGlobalParams()">Show all global params</button>
+	<button onclick="getReferencedGlobalParams()">Show Refernced global params</button>
 </div>
 <div id="currentCommand">
 


### PR DESCRIPTION
# Summary
Added a method to the language service (and worker API) that will retrieve only the global parameters that are actually referenced in the query.