### PR TITLE
Add ability to grab render operator information for the query in context.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
 		"**/node_modules": true,
 		"**/release": true,
 		"**/out": true
-	}
+	},
+	"typescript.tsdk": "node_modules\\typescript\\lib"
 }

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Kusto language plugin for the Monaco Editor. It provides the following features 
 
 ## Changelog
 
+### 2.0.6
+
+#### Added
+
+-   Added `getVisualizationOptions` that returns the render command visualization options in a query.
+
 ### 2.0.5
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Kusto language plugin for the Monaco Editor. It provides the following features 
 
 #### Added
 
--   Added `getVisualizationOptions` that returns the render command visualization options in a query.
+-   Added `getRenderInfo` that returns the render command visualization options in a query.
 
 ### 2.0.5
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/src/kustoWorker.ts
+++ b/src/kustoWorker.ts
@@ -12,7 +12,8 @@ import {
 } from './languageService/schema';
 import * as ls from 'vscode-languageserver-types';
 import { FoldingRange } from 'vscode-languageserver-protocol-foldingprovider';
-import { ColorizationRange, RenderOptions } from './languageService/kustoLanguageService';
+import { ColorizationRange } from './languageService/kustoLanguageService';
+import { RenderInfo } from './languageService/renderInfo';
 
 export class KustoWorker {
     // --- model sync -----------------------
@@ -107,19 +108,31 @@ export class KustoWorker {
         return referencedParams;
     }
 
-    getVisualizationOptions(uri: string, cursorOffset: number): Promise<RenderOptions | undefined> {
+    toRange(range: ls.Range): monaco.Range {
+        if (!range) {
+            return void 0;
+        }
+        return new monaco.Range(
+            range.start.line + 1,
+            range.start.character + 1,
+            range.end.line + 1,
+            range.end.character + 1
+        );
+    }
+
+    getRenderInfo(uri: string, cursorOffset: number): Promise<RenderInfo | null> {
         const document = this._getTextDocument(uri);
         if (!document) {
-            console.error(`getVisualizationOptions: document is ${document}. uri is ${uri}`);
+            console.error(`getRenderInfo: document is ${document}. uri is ${uri}`);
         }
 
-        const visualizationOptions = this._languageService.getVisualizationOptions(document, cursorOffset);
+        return this._languageService.getRenderInfo(document, cursorOffset).then(result => {
+            if (!result) {
+                return null;
+            }
 
-        if (visualizationOptions === undefined) {
-            return null;
-        }
-
-        return visualizationOptions;
+            return result;
+        });
     }
 
     /**

--- a/src/kustoWorker.ts
+++ b/src/kustoWorker.ts
@@ -12,7 +12,7 @@ import {
 } from './languageService/schema';
 import * as ls from 'vscode-languageserver-types';
 import { FoldingRange } from 'vscode-languageserver-protocol-foldingprovider';
-import { ColorizationRange } from './languageService/kustoLanguageService';
+import { ColorizationRange, RenderOptions } from './languageService/kustoLanguageService';
 
 export class KustoWorker {
     // --- model sync -----------------------
@@ -105,6 +105,21 @@ export class KustoWorker {
         }
 
         return referencedParams;
+    }
+
+    getVisualizationOptions(uri: string, cursorOffset: number): Promise<RenderOptions | undefined> {
+        const document = this._getTextDocument(uri);
+        if (!document) {
+            console.error(`getVisualizationOptions: document is ${document}. uri is ${uri}`);
+        }
+
+        const visualizationOptions = this._languageService.getVisualizationOptions(document, cursorOffset);
+
+        if (visualizationOptions === undefined) {
+            return null;
+        }
+
+        return visualizationOptions;
     }
 
     /**

--- a/src/kustoWorker.ts
+++ b/src/kustoWorker.ts
@@ -108,18 +108,6 @@ export class KustoWorker {
         return referencedParams;
     }
 
-    toRange(range: ls.Range): monaco.Range {
-        if (!range) {
-            return void 0;
-        }
-        return new monaco.Range(
-            range.start.line + 1,
-            range.start.character + 1,
-            range.end.line + 1,
-            range.end.character + 1
-        );
-    }
-
     getRenderInfo(uri: string, cursorOffset: number): Promise<RenderInfo | null> {
         const document = this._getTextDocument(uri);
         if (!document) {

--- a/src/languageService/kustoLanguageService.ts
+++ b/src/languageService/kustoLanguageService.ts
@@ -1009,8 +1009,8 @@ class KustoLanguageService implements LanguageService {
         return Promise.as(queryParams);
     }
 
-    async getVisualizationOptions(document: ls.TextDocument, cursorOffset: number): Promise<RenderOptions | undefined> {
-        const parsedAndAnalyzed = await this.parseAndAnalyze(document, cursorOffset);
+    getVisualizationOptions(document: ls.TextDocument, cursorOffset: number): Promise<RenderOptions | undefined> {
+        const parsedAndAnalyzed = this.parseAndAnalyze(document, cursorOffset);
         if (!parsedAndAnalyzed) {
             return Promise.as(undefined);
         }
@@ -1074,7 +1074,7 @@ class KustoLanguageService implements LanguageService {
             {} as RenderOptions
         );
 
-        return { visualization, ...props };
+        return Promise.as({ visualization, ...props });
     }
 
     getReferencedGlobalParams(
@@ -1871,26 +1871,23 @@ class KustoLanguageService implements LanguageService {
         return conversion || k2.ClassificationKind.PlainText;
     }
 
-    private parseAndAnalyze(
-        document: ls.TextDocument,
-        cursorOffset: number
-    ): Promise<Kusto.Language.KustoCode | undefined> {
+    private parseAndAnalyze(document: ls.TextDocument, cursorOffset: number): Kusto.Language.KustoCode | undefined {
         if (!this.isIntellisenseV2()) {
-            return Promise.as(undefined);
+            return undefined;
         }
 
         const script = this.parseDocumentV2(document);
         let currentBlock = this.getCurrentCommandV2(script, cursorOffset);
 
         if (!currentBlock) {
-            return Promise.as(undefined);
+            return undefined;
         }
 
         const text = currentBlock.Text;
 
         const parsedAndAnalyzed = Kusto.Language.KustoCode.ParseAndAnalyze(text, this._kustoJsSchemaV2);
 
-        return Promise.as(parsedAndAnalyzed);
+        return parsedAndAnalyzed;
     }
 }
 

--- a/src/languageService/renderInfo.ts
+++ b/src/languageService/renderInfo.ts
@@ -1,0 +1,47 @@
+export declare type VisualizationType =
+    | 'anomalychart'
+    | 'areachart'
+    | 'barchart'
+    | 'columnchart'
+    | 'ladderchart'
+    | 'linechart'
+    | 'piechart'
+    | 'pivotchart'
+    | 'scatterchart'
+    | 'stackedareachart'
+    | 'timechart'
+    | 'table'
+    | 'timeline'
+    | 'timepivot'
+    | 'card';
+
+export declare type Scale = 'linear' | 'log';
+export declare type LegendVisibility = 'visible' | 'hidden';
+export declare type YSplit = 'none' | 'axes' | 'panels';
+export declare type Kind = 'default' | 'unstacked' | 'stacked' | 'stacked100';
+
+export interface RenderOptions {
+    visualization?: VisualizationType;
+    title?: string;
+    xcolumn?: string;
+    series?: string[];
+    ycolumns?: string[];
+    xtitle?: string;
+    ytitle?: string;
+    xaxis?: Scale;
+    yaxis?: Scale;
+    legend?: LegendVisibility;
+    ySplit?: YSplit;
+    accumulate?: boolean;
+    kind?: Kind;
+    anomalycolumns?: string[];
+    ymin?: number;
+    ymax?: number;
+}
+
+export interface RenderInfo {
+    options: RenderOptions;
+    location: { startOffset: number; endOffset: number };
+}
+
+export type RenderOptionKeys = keyof RenderOptions;

--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -92,6 +92,11 @@ declare module monaco.languages.kusto {
          * It is also different from getGlobalParams that will return all global parameters whether used or not.
          */
         getReferencedGlobalParams(uri: string): Promise<{ name: string; type: string }[]>;
+
+        /**
+         * Get visualization options in render command if present (null otherwise).
+         */
+        getVisualizationOptions(uri: string, cursorOffset: number): Promise<VisualizationOptions | null>;
     }
 
     /**
@@ -155,5 +160,5 @@ declare module monaco.languages.kusto {
 
     export type Schema = EngineSchema | ClusterMangerSchema | DataManagementSchema;
 
-    export var getKustoWorker: () => monaco.Promise<WorkerAccessor>;
+    export var getKustoWorker: () => Promise<WorkerAccessor>;
 }

--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -96,7 +96,7 @@ declare module monaco.languages.kusto {
         /**
          * Get visualization options in render command if present (null otherwise).
          */
-        getVisualizationOptions(uri: string, cursorOffset: number): Promise<VisualizationOptions | null>;
+        getrenderInfo(uri: string, cursorOffset: number): Promise<RenderInfo | null>;
     }
 
     /**
@@ -161,4 +161,52 @@ declare module monaco.languages.kusto {
     export type Schema = EngineSchema | ClusterMangerSchema | DataManagementSchema;
 
     export var getKustoWorker: () => Promise<WorkerAccessor>;
+
+    export declare type VisualizationType =
+        | 'anomalychart'
+        | 'areachart'
+        | 'barchart'
+        | 'columnchart'
+        | 'ladderchart'
+        | 'linechart'
+        | 'piechart'
+        | 'pivotchart'
+        | 'scatterchart'
+        | 'stackedareachart'
+        | 'timechart'
+        | 'table'
+        | 'timeline'
+        | 'timepivot'
+        | 'card';
+
+    export declare type Scale = 'linear' | 'log';
+    export declare type LegendVisibility = 'visible' | 'hidden';
+    export declare type YSplit = 'none' | 'axes' | 'panels';
+    export declare type Kind = 'default' | 'unstacked' | 'stacked' | 'stacked100';
+
+    export interface RenderOptions {
+        visualization?: VisualizationType;
+        title?: string;
+        xcolumn?: string;
+        series?: string[];
+        ycolumns?: string[];
+        xtitle?: string;
+        ytitle?: string;
+        xaxis?: Scale;
+        yaxis?: Scale;
+        legend?: LegendVisibility;
+        ySplit?: YSplit;
+        accumulate?: boolean;
+        kind?: Kind;
+        anomalycolumns?: string[];
+        ymin?: number;
+        ymax?: number;
+    }
+
+    export interface RenderInfo {
+        options: RenderOptions;
+        location: { startOffset: number; endOffset: number };
+    }
+
+    export type RenderOptionKeys = keyof RenderOptions;
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "umd",
         "moduleResolution": "node",
         "outDir": "../out",
-        "target": "es5",
+        "target": "es6",
         "alwaysStrict": true,
         "declaration": true,
         "skipLibCheck": true

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "umd",
         "moduleResolution": "node",
         "outDir": "../out",
-        "target": "es6",
+        "target": "es5",
         "alwaysStrict": true,
         "declaration": true,
         "skipLibCheck": true

--- a/src/workerManager.ts
+++ b/src/workerManager.ts
@@ -1,106 +1,107 @@
-import {LanguageServiceDefaultsImpl} from './monaco.contribution';
-import {KustoWorker} from './kustoWorker';
+import { LanguageServiceDefaultsImpl } from './monaco.contribution';
+import { KustoWorker } from './kustoWorker';
 
 import Promise = monaco.Promise;
 import IDisposable = monaco.IDisposable;
 import Uri = monaco.Uri;
 
 export class WorkerManager {
-	private _storedState: {
-		schema: any,
-	};
+    private _storedState: {
+        schema: any;
+    };
 
-	private _defaults: LanguageServiceDefaultsImpl;
-	private _idleCheckInterval: number;
-	private _lastUsedTime: number;
-	private _configChangeListener: IDisposable;
+    private _defaults: LanguageServiceDefaultsImpl;
+    private _idleCheckInterval: number;
+    private _lastUsedTime: number;
+    private _configChangeListener: IDisposable;
 
-	private _worker: monaco.editor.MonacoWebWorker<KustoWorker>;
-	private _client: Promise<KustoWorker>;
+    private _worker: monaco.editor.MonacoWebWorker<KustoWorker>;
+    private _client: Promise<KustoWorker>;
 
-	constructor(defaults: LanguageServiceDefaultsImpl) {
-		this._defaults = defaults;
-		this._worker = null;
-		this._idleCheckInterval = self.setInterval(() => this._checkIfIdle(), 30 * 1000);
-		this._lastUsedTime = 0;
-		this._configChangeListener = this._defaults.onDidChange(() => this._saveStateAndStopWorker());
-	}
+    constructor(defaults: LanguageServiceDefaultsImpl) {
+        this._defaults = defaults;
+        this._worker = null;
+        this._idleCheckInterval = self.setInterval(() => this._checkIfIdle(), 30 * 1000);
+        this._lastUsedTime = 0;
+        this._configChangeListener = this._defaults.onDidChange(() => this._saveStateAndStopWorker());
+    }
 
-	private _stopWorker(): void {
-		if (this._worker) {
-			this._worker.dispose();
-			this._worker = null;
-		}
-		this._client = null;
-	}
+    private _stopWorker(): void {
+        if (this._worker) {
+            this._worker.dispose();
+            this._worker = null;
+        }
+        this._client = null;
+    }
 
-	private _saveStateAndStopWorker(): void {
-		if (!this._worker) {
-			return;
-		}
+    private _saveStateAndStopWorker(): void {
+        if (!this._worker) {
+            return;
+        }
 
-		this._worker.getProxy().then(proxy => {
-			proxy.getSchema().then(schema => {
-				this._storedState = {schema: schema};
-				this._stopWorker();
-			})
-		})
-	}
+        this._worker.getProxy().then(proxy => {
+            proxy.getSchema().then(schema => {
+                this._storedState = { schema: schema };
+                this._stopWorker();
+            });
+        });
+    }
 
-	dispose(): void {
-		clearInterval(this._idleCheckInterval);
-		this._configChangeListener.dispose();
-		this._stopWorker();
-	}
+    dispose(): void {
+        clearInterval(this._idleCheckInterval);
+        this._configChangeListener.dispose();
+        this._stopWorker();
+    }
 
-	private _checkIfIdle(): void {
-		if (!this._worker) {
-			return;
-		}
-		const maxIdleTime = this._defaults.getWorkerMaxIdleTime();
-		let timePassedSinceLastUsed = Date.now() - this._lastUsedTime;
-		if (maxIdleTime > 0 && timePassedSinceLastUsed > maxIdleTime) {
-			this._saveStateAndStopWorker();
-		}
-	}
+    private _checkIfIdle(): void {
+        if (!this._worker) {
+            return;
+        }
+        const maxIdleTime = this._defaults.getWorkerMaxIdleTime();
+        let timePassedSinceLastUsed = Date.now() - this._lastUsedTime;
+        if (maxIdleTime > 0 && timePassedSinceLastUsed > maxIdleTime) {
+            this._saveStateAndStopWorker();
+        }
+    }
 
-	private _getClient(): Promise<KustoWorker> {
-		this._lastUsedTime = Date.now();
+    private _getClient(): Promise<KustoWorker> {
+        this._lastUsedTime = Date.now();
 
-		if (!this._client) {
-			this._worker = monaco.editor.createWebWorker<KustoWorker>({
+        if (!this._client) {
+            this._worker = monaco.editor.createWebWorker<KustoWorker>({
+                // module that exports the create() method and returns a `KustoWorker` instance
+                moduleId: 'vs/language/kusto/kustoWorker',
 
-				// module that exports the create() method and returns a `KustoWorker` instance
-				moduleId: 'vs/language/kusto/kustoWorker',
+                label: 'kusto',
 
-				label: 'kusto',
+                // passed in to the create() method
+                createData: {
+                    languageSettings: this._defaults.languageSettings,
+                    languageId: 'kusto'
+                }
+            });
 
-				// passed in to the create() method
-				createData: {
-					languageSettings: this._defaults.languageSettings,
-					languageId: 'kusto'
-				}
-			});
+            this._client = this._worker.getProxy().then(proxy => {
+                // push state we held onto before killing the client.
+                if (this._storedState) {
+                    return proxy.setSchema(this._storedState.schema).then(() => proxy);
+                } else {
+                    return proxy;
+                }
+            });
+        }
+        return this._client;
+    }
 
-			this._client = this._worker.getProxy().then(proxy => {
-
-				// push state we held onto before killing the client.
-				if (this._storedState) {
-					return proxy.setSchema(this._storedState.schema).then(() => proxy);
-				} else {
-					return proxy;
-				}
-			});
-		}
-		return this._client;
-	}
-
-	getLanguageServiceWorker(...resources: Uri[]): Promise<KustoWorker> {
-		let _client: KustoWorker;
-		return this._getClient().then((client) => {
-				_client = client
-			}).then(_ => {
-				return this._worker.withSyncedResources(resources)
-			}).then(_ => _client)
-	}
+    getLanguageServiceWorker(...resources: Uri[]): Promise<KustoWorker> {
+        let _client: KustoWorker;
+        return this._getClient()
+            .then(client => {
+                _client = client;
+            })
+            .then(_ => {
+                return this._worker.withSyncedResources(resources);
+            })
+            .then(_ => _client);
+    }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -1,352 +1,414 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-	<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-	<link rel="stylesheet" data-name="vs/editor/editor.main" href="../node_modules/monaco-editor-core/dev/vs/editor/editor.main.css">
-</head>
-<body>
+    <head>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+        <link
+            rel="stylesheet"
+            data-name="vs/editor/editor.main"
+            href="../node_modules/monaco-editor-core/dev/vs/editor/editor.main.css"
+        />
+    </head>
+    <body>
+        <h2>Monaco Editor Kusto test page</h2>
 
-<h2>Monaco Editor Kusto test page</h2>
+        <script></script>
+        <div id="container" style="width:800px;height:600px;border:1px solid grey"></div>
 
-<script>
+        <script>
+            var require = {
+                paths: {
+                    'vs/language/kusto': '../release/dev',
+                    vs: '../node_modules/monaco-editor-core/dev/vs'
+                }
+            };
+        </script>
+        <script src="../node_modules/monaco-editor-core/dev/vs/loader.js"></script>
+        <script src="../node_modules/monaco-editor-core/dev/vs/editor/editor.main.nls.js"></script>
+        <script src="../node_modules/monaco-editor-core/dev/vs/editor/editor.main.js"></script>
+        <script src="../release/min/bridge.min.js"></script>
+        <script src="../release/min/kusto.javascript.client.min.js"></script>
+        <script src="../release/min/Kusto.Language.Bridge.min.js"></script>
 
-</script>
-<div id="container" style="width:800px;height:600px;border:1px solid grey"></div>
+        <script>
+            var setHelpWithParameter;
+            var getCurrentCommand;
+            var getQueryParams;
+            var getGlobalParams;
+            var getReferencedGlobalParams;
+            var getVisualizationOptions;
+            var setDM;
+            var setHelp;
+            var setKuskus;
+            var setSemanticOff;
+            var setSemanticOn;
+            var setIntellisenseV2;
+            var setIntellisenseV1;
+            var setDarkTheme;
+            var setLightTheme;
+            var setDisableClusterCompletion;
+            var setEnableClusterCompletion;
+            require(['vs/language/kusto/monaco.contribution'], function() {
+                var editor = monaco.editor.create(document.getElementById('container'), {
+                    value: ['StormEvents | project StartTime , State | where toupper(State) == "Texas" | count'].join(
+                        '\n'
+                    ),
+                    language: 'kusto',
+                    selectionHighlight: false,
+                    theme: 'kusto-light',
+                    folding: true
+                });
+                getCurrentCommand = () => {
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const model = editor.getModel();
+                        workerAccessor(model.uri).then(worker => {
+                            worker
+                                .getCommandAndLocationInContext(
+                                    model.uri.toString(),
+                                    model.getOffsetAt(editor.getPosition())
+                                )
+                                .then(command => {
+                                    const { text, range } = command;
+                                    const currentCommand = document.getElementById('currentCommand');
+                                    currentCommand.innerHTML = range.toString() + text;
+                                });
+                        });
+                    });
+                };
+                getQueryParams = () => {
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const model = editor.getModel();
+                        workerAccessor(model.uri).then(worker => {
+                            worker
+                                .getQueryParams(model.uri.toString(), model.getOffsetAt(editor.getPosition()))
+                                .then(queryParams => {
+                                    currentCommand.innerHTML = JSON.stringify(queryParams);
+                                });
+                        });
+                    });
+                };
 
-<script>
-	var require = {
-		paths: {
-			'vs/language/kusto': '../release/dev',
-			'vs': '../node_modules/monaco-editor-core/dev/vs'
-		}
-	};
-</script>
-<script src="../node_modules/monaco-editor-core/dev/vs/loader.js"></script>
-<script src="../node_modules/monaco-editor-core/dev/vs/editor/editor.main.nls.js"></script>
-<script src="../node_modules/monaco-editor-core/dev/vs/editor/editor.main.js"></script>
-<script src="../release/min/bridge.min.js"></script>
-<script src="../release/min/kusto.javascript.client.min.js"></script>
-<script src="../release/min/Kusto.Language.Bridge.min.js"></script>
+                getGlobalParams = () => {
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const model = editor.getModel();
+                        workerAccessor(model.uri).then(worker => {
+                            worker.getGlobalParams(model.uri.toString()).then(queryParams => {
+                                currentCommand.innerHTML = JSON.stringify(queryParams);
+                            });
+                        });
+                    });
+                };
 
-<script>
-	var setHelpWithParameter;
-	var getCurrentCommand;
-	var getQueryParams;
-	var getGlobalParams;
-	var getReferencedGlobalParams;
-	var setDM;
-	var setHelp;
-	var setKuskus;
-	var setSemanticOff;
-	var setSemanticOn;
-	var setIntellisenseV2;
-	var setIntellisenseV1;
-	var setDarkTheme;
-	var setLightTheme;
-	var setDisableClusterCompletion;
-	var setEnableClusterCompletion;
-	require([
-		'vs/language/kusto/monaco.contribution'
-	], function() {
-		var editor = monaco.editor.create(document.getElementById('container'), {
-			value: ['StormEvents | project StartTime , State | where toupper(State) == "Texas" | count'].join('\n'),
-			language: 'kusto',
-			selectionHighlight:false,
-			theme: 'kusto-light',
-			folding: true
-		});
-		getCurrentCommand = () => {
-			monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const model = editor.getModel();
-			workerAccessor(model.uri).then(worker => {
-				worker.getCommandAndLocationInContext(model.uri.toString(), model.getOffsetAt(editor.getPosition())).then(command => {
-					const {text, range} = command;
-					const currentCommand = document.getElementById('currentCommand');
-					currentCommand.innerHTML = range.toString() + text;
-				})
-			});
-		})};
-		getQueryParams = () => {
-			monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const model = editor.getModel();
-			workerAccessor(model.uri).then(worker => {
-				worker.getQueryParams(model.uri.toString(), model.getOffsetAt(editor.getPosition())).then(queryParams => {
-					currentCommand.innerHTML = JSON.stringify(queryParams);
-				})
-			});
-		});
-		}
+                getReferencedGlobalParams = () => {
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const model = editor.getModel();
+                        workerAccessor(model.uri).then(worker => {
+                            worker
+                                .getReferencedGlobalParams(
+                                    model.uri.toString(),
+                                    model.getOffsetAt(editor.getPosition())
+                                )
+                                .then(referencedParams => {
+                                    currentCommand.innerHTML = JSON.stringify(referencedParams);
+                                });
+                        });
+                    });
+                };
 
-		getGlobalParams = () => {
-			monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const model = editor.getModel();
-			workerAccessor(model.uri).then(worker => {
-				worker.getGlobalParams(model.uri.toString()).then(queryParams => {
-					currentCommand.innerHTML = JSON.stringify(queryParams);
-				})
-			});
-		});
-		}
+                getVisualizationOptions = () => {
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const model = editor.getModel();
+                        workerAccessor(model.uri).then(worker => {
+                            worker
+                                .getVisualizationOptions(model.uri.toString(), model.getOffsetAt(editor.getPosition()))
+                                .then(visualizationOptions => {
+                                    currentCommand.innerHTML = JSON.stringify(visualizationOptions);
+                                });
+                        });
+                    });
+                };
 
-		getReferencedGlobalParams = () => {
-			monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const model = editor.getModel();
-			workerAccessor(model.uri).then(worker => {
-				worker.getReferencedGlobalParams(model.uri.toString(), model.getOffsetAt(editor.getPosition())).then(referencedParams => {
-					currentCommand.innerHTML = JSON.stringify(referencedParams);
-				})
-			});
-		});
-		}
+                setDM = () => {
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const model = editor.getModel();
+                        workerAccessor(model.uri).then(worker => {
+                            worker.setSchema(null, 'DataManagement');
+                        });
+                    });
+                };
 
-		setDM = () => {
-			monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const model = editor.getModel();
-			workerAccessor(model.uri).then(worker => {
-				worker.setSchema(null, 'DataManagement');
-			});
-		})};
-
-		monaco.languages.kusto.kustoDefaults.setLanguageSettings({includeControlCommands: true, newlineAfterPipe: true, useIntellisenseV2: true, useSemanticColorization: true});
-		const schema = {
-			"Plugins": [{
-				"Name": "pivot"
-			}
-			],
-			"Databases": {
-				"Samples": {
-					"Name": "Samples",
-					"Tables": {
-						"StormEvents": {
-							"Name": "StormEvents",
-							"OrderedColumns": [{
-								"Name": "StartTime",
-								"Type": "System.DateTime",
-								"CslType": "datetime"
-							}, {
-								"Name": "EndTime",
-								"Type": "System.DateTime",
-								"CslType": "datetime"
-							}, {
-								"Name": "EpisodeId",
-								"Type": "System.Int32",
-								"CslType": "int"
-							}, {
-								"Name": "EventId",
-								"Type": "System.Int32",
-								"CslType": "int"
-							}, {
-								"Name": "State",
-								"Type": "System.String",
-								"CslType": "string"
-							}
-							]
-						}, "ForecastExample": {
-							"Name": "ForecastExample",
-							"OrderedColumns": [{
-								"Name": "Timestamp",
-								"Type": "System.DateTime",
-								"CslType": "datetime"
-							}, {
-								"Name": "RequestCount",
-								"Type": "System.Int64",
-								"CslType": "long"
-							}
-							]
-						}
-					},
-					"Functions": {
-						"MyFunction1": {
-							"Name": "MyFunction1",
-							"InputParameters": [],
-							"Body": "{     StormEvents     | limit 100 }  ",
-							"Folder": "Demo",
-							"DocString": "Simple demo function",
-							"FunctionKind": "Unknown",
-							"OutputColumns": []
-						},
-						"MyFunction2": {
-							"Name": "MyFunction2",
-							"InputParameters": [{
-								"Name": "myLimit",
-								"Type": "System.Int64",
-								"CslType": "long"
-							}
-							],
-							"Body": "{     StormEvents     | limit myLimit }  ",
-							"Folder": "Demo",
-							"DocString": "Demo function with parameter",
-							"FunctionKind": "Unknown",
-							"OutputColumns": []
-						}
-					}
-				}
-			}
-
-		};
-		const schema2 = {
-			"Plugins": [{
-				"Name": "pivot"
-			}
-			],
-			"Databases": {
-				"Kuskus": {
-					"Name": "Kuskus",
-					"Tables": {
-						"KustoLogs": {
-							"Name": "KustoLogs",
-							"OrderedColumns": [{
-								"Name": "Timestamp",
-								"Type": "System.DateTime",
-								"CslType": "datetime"
-							}, {
-								"Name": "EventText",
-								"Type": "System.String",
-								"CslType": "string"
-							}, {
-								"Name": "Level",
-								"Type": "System.String",
-								"CslType": "string"
-							}, {
-								"Name": "Source",
-								"Type": "System.String",
-								"CslType": "string"
-							}
-							]
-						}, "Usage": {
-							"Name": "Usage",
-							"OrderedColumns": [{
-								"Name": "StartedOn",
-								"Type": "System.DateTime",
-								"CslType": "datetime"
-							}, {
-								"Name": "User",
-								"Type": "System.String",
-								"CslType": "string"
-							}
-							]
-						}
-					},
-					"Functions": {
-						"FindCIDPast24h": {
-							"Name": "FindCIDPast24h",
-							"InputParameters": [],
-							"Body": "{     KustoLogs     | limit 100 }  ",
-							"Folder": "Demo",
-							"DocString": "Find CID past 24 hours",
-							"FunctionKind": "Unknown",
-							"OutputColumns": []
-						},
-						"MyFunction2": {
-							"Name": "FindCID",
-							"InputParameters": [{
-								"Name": "cid",
-								"Type": "System.String",
-								"CslType": "string"
-
-							},{
-								"Name": "startTime",
-								"Type": "System.Datetime",
-								"CslType": "datetime"
-							}
-							],
-							"Body": "{     KustoLogs     | where Timestamp > startTime | where EventText has cid }  ",
-							"Folder": "Demo",
-							"DocString": "Find  CID in after a cetain time",
-							"FunctionKind": "Unknown",
-							"OutputColumns": []
-						}
-					}
-				}
-			}
-
-		};
-		setHelp = () => monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const model = editor.getModel();
-			workerAccessor(model.uri).then(worker => {
-				worker.setSchemaFromShowSchema(schema, "https://help.kusto.windows.net", 'Samples');
-			});
-		});
-		setHelpWithParameter = () => monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const model = editor.getModel();
-			workerAccessor(model.uri).then(worker => {
-				worker.setSchemaFromShowSchema(schema, "https://help.kusto.windows.net", 'Samples', [{name: 'region', type: 'System.String', cslType: 'string'}]);
-			});
-		});
-		setKuskus = () => monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const model = editor.getModel();
-			workerAccessor(model.uri).then(worker => {
-				worker.setSchemaFromShowSchema(schema2, "https://kuskus.kusto.windows.net", 'Kuskus');
-			});
-		});
-		setSemanticOff = () => monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
-			monaco.useSemanticColorization = false;
-			monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
-		});
-		setSemanticOn = () => monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
-			monaco.useSemanticColorization = true;
-			monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
-		});
-		setIntellisenseV1 = () => monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
-			monacoSettings.useIntellisenseV2 = false;
-			monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
-		});
-		setIntellisenseV2 = () => monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
-			monacoSettings.useIntellisenseV2 = true;
-			monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
-		});
-		setDarkTheme = () => monaco.editor.setTheme('kusto-dark');
-		setLightTheme = () => monaco.editor.setTheme('kusto-light');
-		setDisableClusterCompletion = () => monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
-			monacoSettings.disabledCompletionItems = ['cluster', 'database'];
-			monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
-		});
-		setEnableClusterCompletion = () => monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
-			const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
-			monacoSettings.disabledCompletionItems = [];
-			monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
-		});
-		setHelp();
-	});
-</script>
-<div>
-	<button onclick="setKuskus()">Kuskus</button>
-	<button onclick="setHelp()">Help</button>
-	<button onclick="setHelpWithParameter()">Help with injected parameter</button>
-	<button onclick="setDM()">DM</button>
-</div>
-<div>
-	<button onclick="setSemanticOff()">Semantic colorization Off</button>
-	<button onclick="setSemanticOn()">Semantic colorization On</button>
-</div>
-<div>
-	<button onclick="setIntellisenseV1()">V1 Intellisense</button>
-	<button onclick="setIntellisenseV2()">V2 Intellisense</button>
-</div>
-<div>
-	<button onClick="setDarkTheme()">Dark Theme</button>
-	<button onClick="setLightTheme()">Light Theme</button>
-</div>
-<div>
-	<button onClick="setDisableClusterCompletion()">Disable Cluster keyword completion</button>
-	<button onClick="setEnableClusterCompletion()">Enalbe Cluster keyword completion</button>
-</div>
-<div>
-	<button onclick="getCurrentCommand()">Show current Command and position</button>
-</div>
-<div>
-	<button onclick="getQueryParams()">Show current query params</button>
-	<button onclick="getGlobalParams()">Show all global params</button>
-	<button onclick="getReferencedGlobalParams()">Show Refernced global params</button>
-</div>
-<div id="currentCommand">
-
-</div>
-</body>
+                monaco.languages.kusto.kustoDefaults.setLanguageSettings({
+                    includeControlCommands: true,
+                    newlineAfterPipe: true,
+                    useIntellisenseV2: true,
+                    useSemanticColorization: true
+                });
+                const schema = {
+                    Plugins: [
+                        {
+                            Name: 'pivot'
+                        }
+                    ],
+                    Databases: {
+                        Samples: {
+                            Name: 'Samples',
+                            Tables: {
+                                StormEvents: {
+                                    Name: 'StormEvents',
+                                    OrderedColumns: [
+                                        {
+                                            Name: 'StartTime',
+                                            Type: 'System.DateTime',
+                                            CslType: 'datetime'
+                                        },
+                                        {
+                                            Name: 'EndTime',
+                                            Type: 'System.DateTime',
+                                            CslType: 'datetime'
+                                        },
+                                        {
+                                            Name: 'EpisodeId',
+                                            Type: 'System.Int32',
+                                            CslType: 'int'
+                                        },
+                                        {
+                                            Name: 'EventId',
+                                            Type: 'System.Int32',
+                                            CslType: 'int'
+                                        },
+                                        {
+                                            Name: 'State',
+                                            Type: 'System.String',
+                                            CslType: 'string'
+                                        }
+                                    ]
+                                },
+                                ForecastExample: {
+                                    Name: 'ForecastExample',
+                                    OrderedColumns: [
+                                        {
+                                            Name: 'Timestamp',
+                                            Type: 'System.DateTime',
+                                            CslType: 'datetime'
+                                        },
+                                        {
+                                            Name: 'RequestCount',
+                                            Type: 'System.Int64',
+                                            CslType: 'long'
+                                        }
+                                    ]
+                                }
+                            },
+                            Functions: {
+                                MyFunction1: {
+                                    Name: 'MyFunction1',
+                                    InputParameters: [],
+                                    Body: '{     StormEvents     | limit 100 }  ',
+                                    Folder: 'Demo',
+                                    DocString: 'Simple demo function',
+                                    FunctionKind: 'Unknown',
+                                    OutputColumns: []
+                                },
+                                MyFunction2: {
+                                    Name: 'MyFunction2',
+                                    InputParameters: [
+                                        {
+                                            Name: 'myLimit',
+                                            Type: 'System.Int64',
+                                            CslType: 'long'
+                                        }
+                                    ],
+                                    Body: '{     StormEvents     | limit myLimit }  ',
+                                    Folder: 'Demo',
+                                    DocString: 'Demo function with parameter',
+                                    FunctionKind: 'Unknown',
+                                    OutputColumns: []
+                                }
+                            }
+                        }
+                    }
+                };
+                const schema2 = {
+                    Plugins: [
+                        {
+                            Name: 'pivot'
+                        }
+                    ],
+                    Databases: {
+                        Kuskus: {
+                            Name: 'Kuskus',
+                            Tables: {
+                                KustoLogs: {
+                                    Name: 'KustoLogs',
+                                    OrderedColumns: [
+                                        {
+                                            Name: 'Timestamp',
+                                            Type: 'System.DateTime',
+                                            CslType: 'datetime'
+                                        },
+                                        {
+                                            Name: 'EventText',
+                                            Type: 'System.String',
+                                            CslType: 'string'
+                                        },
+                                        {
+                                            Name: 'Level',
+                                            Type: 'System.String',
+                                            CslType: 'string'
+                                        },
+                                        {
+                                            Name: 'Source',
+                                            Type: 'System.String',
+                                            CslType: 'string'
+                                        }
+                                    ]
+                                },
+                                Usage: {
+                                    Name: 'Usage',
+                                    OrderedColumns: [
+                                        {
+                                            Name: 'StartedOn',
+                                            Type: 'System.DateTime',
+                                            CslType: 'datetime'
+                                        },
+                                        {
+                                            Name: 'User',
+                                            Type: 'System.String',
+                                            CslType: 'string'
+                                        }
+                                    ]
+                                }
+                            },
+                            Functions: {
+                                FindCIDPast24h: {
+                                    Name: 'FindCIDPast24h',
+                                    InputParameters: [],
+                                    Body: '{     KustoLogs     | limit 100 }  ',
+                                    Folder: 'Demo',
+                                    DocString: 'Find CID past 24 hours',
+                                    FunctionKind: 'Unknown',
+                                    OutputColumns: []
+                                },
+                                MyFunction2: {
+                                    Name: 'FindCID',
+                                    InputParameters: [
+                                        {
+                                            Name: 'cid',
+                                            Type: 'System.String',
+                                            CslType: 'string'
+                                        },
+                                        {
+                                            Name: 'startTime',
+                                            Type: 'System.Datetime',
+                                            CslType: 'datetime'
+                                        }
+                                    ],
+                                    Body:
+                                        '{     KustoLogs     | where Timestamp > startTime | where EventText has cid }  ',
+                                    Folder: 'Demo',
+                                    DocString: 'Find  CID in after a cetain time',
+                                    FunctionKind: 'Unknown',
+                                    OutputColumns: []
+                                }
+                            }
+                        }
+                    }
+                };
+                setHelp = () =>
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const model = editor.getModel();
+                        workerAccessor(model.uri).then(worker => {
+                            worker.setSchemaFromShowSchema(schema, 'https://help.kusto.windows.net', 'Samples');
+                        });
+                    });
+                setHelpWithParameter = () =>
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const model = editor.getModel();
+                        workerAccessor(model.uri).then(worker => {
+                            worker.setSchemaFromShowSchema(schema, 'https://help.kusto.windows.net', 'Samples', [
+                                { name: 'region', type: 'System.String', cslType: 'string' }
+                            ]);
+                        });
+                    });
+                setKuskus = () =>
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const model = editor.getModel();
+                        workerAccessor(model.uri).then(worker => {
+                            worker.setSchemaFromShowSchema(schema2, 'https://kuskus.kusto.windows.net', 'Kuskus');
+                        });
+                    });
+                setSemanticOff = () =>
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
+                        monaco.useSemanticColorization = false;
+                        monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
+                    });
+                setSemanticOn = () =>
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
+                        monaco.useSemanticColorization = true;
+                        monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
+                    });
+                setIntellisenseV1 = () =>
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
+                        monacoSettings.useIntellisenseV2 = false;
+                        monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
+                    });
+                setIntellisenseV2 = () =>
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
+                        monacoSettings.useIntellisenseV2 = true;
+                        monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
+                    });
+                setDarkTheme = () => monaco.editor.setTheme('kusto-dark');
+                setLightTheme = () => monaco.editor.setTheme('kusto-light');
+                setDisableClusterCompletion = () =>
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
+                        monacoSettings.disabledCompletionItems = ['cluster', 'database'];
+                        monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
+                    });
+                setEnableClusterCompletion = () =>
+                    monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
+                        const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
+                        monacoSettings.disabledCompletionItems = [];
+                        monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
+                    });
+                setHelp();
+            });
+        </script>
+        <div>
+            <button onclick="setKuskus()">Kuskus</button>
+            <button onclick="setHelp()">Help</button>
+            <button onclick="setHelpWithParameter()">Help with injected parameter</button>
+            <button onclick="setDM()">DM</button>
+        </div>
+        <div>
+            <button onclick="setSemanticOff()">Semantic colorization Off</button>
+            <button onclick="setSemanticOn()">Semantic colorization On</button>
+        </div>
+        <div>
+            <button onclick="setIntellisenseV1()">V1 Intellisense</button>
+            <button onclick="setIntellisenseV2()">V2 Intellisense</button>
+        </div>
+        <div>
+            <button onClick="setDarkTheme()">Dark Theme</button>
+            <button onClick="setLightTheme()">Light Theme</button>
+        </div>
+        <div>
+            <button onClick="setDisableClusterCompletion()">Disable Cluster keyword completion</button>
+            <button onClick="setEnableClusterCompletion()">Enalbe Cluster keyword completion</button>
+        </div>
+        <div>
+            <button onclick="getCurrentCommand()">Show current Command and position</button>
+        </div>
+        <div>
+            <button onclick="getQueryParams()">Show current query params</button>
+            <button onclick="getGlobalParams()">Show all global params</button>
+            <button onclick="getReferencedGlobalParams()">Show Refernced global params</button>
+            <button onclick="getVisualizationOptions()">Show Visualization Options</button>
+        </div>
+        <div id="currentCommand"></div>
+    </body>
 </html>

--- a/test/index.html
+++ b/test/index.html
@@ -36,7 +36,7 @@
             var getQueryParams;
             var getGlobalParams;
             var getReferencedGlobalParams;
-            var getVisualizationOptions;
+            var getRenderInfo;
             var setDM;
             var setHelp;
             var setKuskus;
@@ -115,14 +115,14 @@
                     });
                 };
 
-                getVisualizationOptions = () => {
+                getRenderInfo = () => {
                     monaco.languages.kusto.getKustoWorker().then(workerAccessor => {
                         const model = editor.getModel();
                         workerAccessor(model.uri).then(worker => {
                             worker
-                                .getVisualizationOptions(model.uri.toString(), model.getOffsetAt(editor.getPosition()))
-                                .then(visualizationOptions => {
-                                    currentCommand.innerHTML = JSON.stringify(visualizationOptions);
+                                .getRenderInfo(model.uri.toString(), model.getOffsetAt(editor.getPosition()))
+                                .then(renderInfo => {
+                                    currentCommand.innerHTML = JSON.stringify(renderInfo);
                                 });
                         });
                     });
@@ -407,7 +407,7 @@
             <button onclick="getQueryParams()">Show current query params</button>
             <button onclick="getGlobalParams()">Show all global params</button>
             <button onclick="getReferencedGlobalParams()">Show Refernced global params</button>
-            <button onclick="getVisualizationOptions()">Show Visualization Options</button>
+            <button onclick="getRenderInfo()">Show Visualization Options</button>
         </div>
         <div id="currentCommand"></div>
     </body>


### PR DESCRIPTION
### Summary
added the function `getRenderInfo` that returns the returns the position of the render command in current block, and the different render configuration.
 <!--

 Link to the issue describing the bug that you're fixing.

 Provide a general description of the code changes in your pull request.

 -->

 ### Other Information

 <!--

 If there's anything else that's important and relevant to your pull request, mention that information here.

 -->