### PR TITLE
Add an horizontal line in onHover

### DIFF
--- a/src/languageService/kustoLanguageService.ts
+++ b/src/languageService/kustoLanguageService.ts
@@ -1199,8 +1199,9 @@ class KustoLanguageService implements LanguageService {
             return Promise.as(undefined);
         }
 
-        // \n\n doesn't work in a markdown, it won't create an empty line. So instead use "\n\n&nbsp;\n\n".
-        return Promise.as({ contents: quickInfo.Text.replace("\n\n", "\n\n&nbsp;\n\n") });
+        // Instead of just an empty line between the first line (the signature) and the second line (the description)
+        // add an horizontal line (* * * in markdown) between them.
+        return Promise.as({ contents: quickInfo.Text.replace("\n\n", "\n* * *\n") });
     }
 
     //#region dummy schema for manual testing


### PR DESCRIPTION
### Summary

Instead of just an empty line between the first line (the signature)
and the second line (the description)
add an horizontal line (* * * in markdown) between them.

Before:
![image](https://user-images.githubusercontent.com/8294298/87067193-9378aa00-c1c8-11ea-91ea-9b1974a791d6.png)

After:
![image](https://user-images.githubusercontent.com/8294298/87067064-675d2900-c1c8-11ea-9fdb-1bee1136f839.png)

