### PR TITLE
Don't throw when database has no functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@ Kusto language plugin for the Monaco Editor. It provides the following features 
 -   code folding / outlining
 -   Hovers
 -   Find definition
--   find all refernces
+-   find all references
 -   rename symbol
 
 ## Setting a schema
 There are 2 APIs to set a Kusto schema:
-1. `setSchema` - the passed schema is of type `ClusterType` (defined in `schema.ts`). The logic to find the cluster/database in context from the schema is:
-    - cluster: first cluster with empty connection string
-    - database: the database in ROOT.database
-2. `setSchemaFromShowSchema` - a method to set a schema from the result of the Kusto query `.show schema as json`. The result is a list of databases (see interface `Result` in `schema.ts`), so when this method is used, it also requires a cluster URI and the database in context.
+1. `setSchema` - the passed schema is of type `ClusterType` (defined in `schema.ts`).
+    The database in ROOT.database will be the one in context.
+2. `setSchemaFromShowSchema` - a method to set a schema from the result of the Kusto query `.show schema as json`.
+   The result is a list of databases (see interface `Result` in `schema.ts`), so when this method is used,
+   it also requires a cluster URI and the name of the database in context.
 
 ## Setting up a dev environment
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Kusto language plugin for the Monaco Editor. It provides the following features 
 -   find all refernces
 -   rename symbol
 
+## Setting a schema
+There are 2 APIs to set a Kusto schema:
+1. `setSchema` - the passed schema is of type `ClusterType` (defined in `schema.ts`). The logic to find the cluster/database in context from the schema is:
+    - cluster: first cluster with empty connection string
+    - database: the database in ROOT.database
+2. `setSchemaFromShowSchema` - a method to set a schema from the result of the Kusto query `.show schema as json`. The result is a list of databases (see interface `Result` in `schema.ts`), so when this method is used, it also requires a cluster URI and the database in context.
+
 ## Setting up a dev environment
 
 1. Install Node.js (v6.10.3 or later) from [https://nodejs.org/](https://nodejs.org/)
@@ -169,6 +176,10 @@ import('monaco.contribution').then(async (contribution: any) => {
 ```
 
 ## Changelog
+
+### 2.1.10
+
+- Schema with no functions was throwing "Cannot read property 'map' of undefined".
 
 ### 2.1.9
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "2.1.9",
+    "version": "2.1.10",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/src/languageService/kustoLanguageService.ts
+++ b/src/languageService/kustoLanguageService.ts
@@ -1455,8 +1455,11 @@ class KustoLanguageService implements LanguageService {
         };
 
         const createDatabaseSymbol: (db: s.Database) => sym.DatabaseSymbol = (db) => {
+            if (!db.tables || db.tables.length === 0) {
+                throw new Error(`can't create a symbol for database '${db.name}'. Database has no tables.`);
+            }
             const tableSymbols: sym.Symbol[] = db.tables.map((tbl) => createTableSymbol(tbl));
-            const functionSymbols = db.functions.map((fun) => createFunctionSymbol(fun));
+            const functionSymbols = db.functions ? db.functions.map((fun) => createFunctionSymbol(fun)) : [];
             return new sym.DatabaseSymbol.ctor(db.name, tableSymbols.concat(functionSymbols));
         };
 

--- a/src/languageService/schema.ts
+++ b/src/languageService/schema.ts
@@ -58,6 +58,12 @@ export interface DataManagementSchema {
     clusterType: 'DataManagement';
 }
 
+/**
+ * Schema types:
+ * Engine – The main schema type. Contains clusters, databases, tables, table columns and functions.
+ * Cluster Manager – Internal only. A schema for clusters that manages other clusters.
+ * Data Management – Internal only. A schema for ingestion point operations.
+ */
 export type Schema = EngineSchema | ClusterMangerSchema | DataManagementSchema;
 
 const dotnetTypeToKustoType = {


### PR DESCRIPTION
### Summary
- Fix bug: "Cannot read property 'map' of undefined" is thrown when database has no functions. 
- update README file to include instructions on how to use setSchema.