### PR TITLE
fix v1 colorization error

### DIFF
--- a/src/languageService/kustoLanguageService.ts
+++ b/src/languageService/kustoLanguageService.ts
@@ -1556,8 +1556,6 @@ class KustoLanguageService implements LanguageService {
                         cslCommandToken.AbsoluteStart + offset,
                         cslCommandToken.Length
                     );
-                    // todo: shouldn't we remove it
-                    range.End = cslCommandToken.AbsoluteEnd + offset;
 
                     return range;
                 }


### PR DESCRIPTION
### Summary

Do not try to set `range.End`. It is a read only property and setting it fails during v1 colorization with: 
```TypeError: Cannot set property End of #<ctor> which has only a getter```

 ### Other Information

following up on #20 #21. The fix was already made in https://github.com/Azure/monaco-kusto/pull/21 but the code has changed since then. 
