### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ import('monaco.contribution').then(async (contribution: any) => {
 
 ## Changelog
 
+### 2.1.11
+
+- Upgrade to latest bridge.net which fixes an exception from indexOf.
+
 ### 2.1.10
 
 - Schema with no functions was throwing "Cannot read property 'map' of undefined".

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "2.1.8",
+  "version": "2.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -736,14 +736,14 @@
       }
     },
     "@kusto/language-service": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/@kusto/language-service/-/language-service-0.0.31.tgz",
-      "integrity": "sha512-g8MMm/NBcp9vGSlnK8mYR/tYBplHaHjkPywVnWRvs/kAgirXAJSH9cj30Vj6ndpUcQukBcIPtiJvpNLLurqbZw=="
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@kusto/language-service/-/language-service-0.0.32.tgz",
+      "integrity": "sha512-HcRg+Bfzwh5OUWJ8m3KbSVDhrm/KmbPBtoY1Q9rBDonmwLwd/geMTfR0S+u5YxFjzzUMBXZIhd3FQqEPIizz7g=="
     },
     "@kusto/language-service-next": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@kusto/language-service-next/-/language-service-next-0.0.36.tgz",
-      "integrity": "sha512-muBEdJYhx4hPSZmSUDwGSKMLF++pfAKH5oqNR11GD25bPLc+IxXIEbcl8sYYnY/5KOYOd9Obyn7fy3WbQGyttg=="
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@kusto/language-service-next/-/language-service-next-0.0.37.tgz",
+      "integrity": "sha512-r/cieTEmRranKGDxPFFCmxFkQ5V8pfilDt/ib+JhEAMTjGjbAkpGFQaVgXd9RUa3aA9hF/ouDdhymcgCvzO52g=="
     },
     "@sinonjs/commons": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "2.1.10",
+    "version": "2.1.11",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"
@@ -54,8 +54,8 @@
         "xregexp": "^3.2.0"
     },
     "dependencies": {
-        "@kusto/language-service": "0.0.31",
-        "@kusto/language-service-next": "0.0.36"
+        "@kusto/language-service": "0.0.32",
+        "@kusto/language-service-next": "0.0.37"
     },
     "peerDependencies": {
         "monaco-editor": "^0.15.6"

--- a/src/languageService/kustoLanguageService.ts
+++ b/src/languageService/kustoLanguageService.ts
@@ -696,7 +696,7 @@ class KustoLanguageService implements LanguageService {
 
         this._schema.globalParameters = parameters;
         const symbols = parameters.map((param) => KustoLanguageService.createParameterSymbol(param));
-        this._kustoJsSchemaV2 = this._kustoJsSchemaV2.WithParameters(symbols);
+        this._kustoJsSchemaV2 = this._kustoJsSchemaV2.WithParameters(KustoLanguageService.toBridgeList(symbols));
 
         return Promise.as(undefined);
     }
@@ -1444,7 +1444,7 @@ class KustoLanguageService implements LanguageService {
             );
 
             // TODO: handle outputColumns (right now it doesn't seem to be implemented for any function).
-            return new sym.FunctionSymbol.$ctor16(fn.name, fn.body, parameters, fn.docstring);
+            return new sym.FunctionSymbol.$ctor16(fn.name, fn.body, KustoLanguageService.toBridgeList(parameters), fn.docstring);
         };
 
         const createTableSymbol: (tbl: s.Table) => sym.TableSymbol = (tbl) => {
@@ -1539,7 +1539,7 @@ class KustoLanguageService implements LanguageService {
             const parameters = schema.globalParameters.map((param) =>
                 KustoLanguageService.createParameterSymbol(param)
             );
-            globalState = globalState.WithParameters(parameters);
+            globalState = globalState.WithParameters(KustoLanguageService.toBridgeList(parameters));
         }
 
         return globalState;
@@ -1870,6 +1870,11 @@ class KustoLanguageService implements LanguageService {
 
     private toArray<T>(bridgeList: System.Collections.Generic.IEnumerable$1<T>): T[] {
         return (Bridge as any).toArray(bridgeList);
+    }
+
+    private static toBridgeList(array): any {
+        // copied from bridge.js from the implementation of Enumerable.prototype.toList
+        return new (System.Collections.Generic.List$1(System.Object).$ctor1)(array);
     }
 
     private _tokenKindToClassificationKind: { [k in TokenKind]: k2.ClassificationKind } = {


### PR DESCRIPTION
### Summary
- this change updates to the latest bridge.net which fixes
an exception during colorization which lead to an incorrect error squiggly lines 
on valid joins. 

The exception was happening when a join has at least one `(` ot `)` in it.

For example:
KustoLogs
| take 10
| join
(
    KustoLogs
    | project EventText=tostring(EventText)
)
on EventText