### PR TITLE
Pretiffer with Kusto.Language

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,17 @@ import('monaco.contribution').then(async (contribution: any) => {
 
 ## Changelog
 
+### 2.1.12
+
+-   Allow formatting commands in cursor location.
+
 ### 2.1.10
 
-- Schema with no functions was throwing "Cannot read property 'map' of undefined".
+-   Schema with no functions was throwing "Cannot read property 'map' of undefined".
 
 ### 2.1.9
 
-- Add DocString to onHover tooltip
+-    Add DocString to onHover tooltip
 
 ### 2.1.6
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "2.1.8",
+  "version": "2.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "2.1.10",
+    "version": "2.1.12",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/src/kustoWorker.ts
+++ b/src/kustoWorker.ts
@@ -171,6 +171,10 @@ export class KustoWorker {
 
     doComplete(uri: string, position: ls.Position): Promise<ls.CompletionList> {
         let document = this._getTextDocument(uri);
+        if (!document) {
+            return null;
+        }
+
         let completions = this._languageService.doComplete(document, position);
         return completions;
     }


### PR DESCRIPTION
### Summary

- Pretify with new API - use Kusto.Language instead of Kusto.JavaScript.Client
- Allow formatting commands in cursor location.

 ### Other Information

 <!--

 If there's anything else that's important and relevant to your pull request, mention that information here.

 -->