### PR TITLE
Allow publishing NPM when pushing to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,5 +37,7 @@ jobs:
     - name: copy types to out folder
       run: npm run copy_types_to_release
     
-#     - name: NPM publish 
-#       uses: JS-DevTools/npm-publish@v1
+    - name: NPM publish 
+      uses: JS-DevTools/npm-publish@v1
+      with:
+          token: ${{ secrets.NPMPUBLISHTOKEN }}


### PR DESCRIPTION
### Summary

With this change, NPM will be published only if the package version is newer. 
NPM publish is done with this tool: https://github.com/marketplace/actions/npm-publish