### PR TITLE
Update NPM publish to do just publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "watch": "echo dev > test/mode.txt && tsc -p ./src/tsconfig.watch.json && npm run copy_runtime_deps_to_out && concurrently \"live-server ./ \" \"tsc -w -p ./src/tsconfig.watch.json \"",
         "test_release": "echo release > test/mode.txt && http-server -c-1 -p 8080 ./ -o index.html",
         "copy_types_to_release": "mcopy ./src/monaco.d.ts ./release/esm/monaco.d.ts && mcopy ./out/amd/monaco.contribution.d.ts ./release/esm/monaco.contribution.d.ts && mcopy ./src/monaco.d.ts ./release/min/monaco.d.ts && mcopy ./out/amd/monaco.contribution.d.ts ./release/min/monaco.contribution.d.ts && mcopy ./node_modules/@kusto/language-service/Kusto.JavaScript.Client.min.js  ./release/min/kusto.javascript.client.min.js && mcopy ./node_modules/@kusto/language-service-next/Kusto.Language.Bridge.min.js ./release/min/Kusto.Language.Bridge.min.js && mcopy ./node_modules/@kusto/language-service/bridge.min.js ./release/min/bridge.min.js && mcopy ./node_modules/@kusto/language-service/newtonsoft.json.min.js ./release/min/newtonsoft.json.min.js",
-        "build_release": "mkdirp release  && npm run compile && node ./scripts/release.js && node ./scripts/bundle.js && npm run copy_runtime_deps_to_out && npm run copy_types_to_release && npm run test_release",
+        "prepublishOnly": "mkdirp release  && npm run compile && node ./scripts/release.js && node ./scripts/bundle.js && npm run copy_runtime_deps_to_out && npm run copy_types_to_release",
         "test": "jest",
         "clean": "mrmdir ./out && mrmdir ./release"
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "watch": "echo dev > test/mode.txt && tsc -p ./src/tsconfig.watch.json && npm run copy_runtime_deps_to_out && concurrently \"live-server ./ \" \"tsc -w -p ./src/tsconfig.watch.json \"",
         "test_release": "echo release > test/mode.txt && http-server -c-1 -p 8080 ./ -o index.html",
         "copy_types_to_release": "mcopy ./src/monaco.d.ts ./release/esm/monaco.d.ts && mcopy ./out/amd/monaco.contribution.d.ts ./release/esm/monaco.contribution.d.ts && mcopy ./src/monaco.d.ts ./release/min/monaco.d.ts && mcopy ./out/amd/monaco.contribution.d.ts ./release/min/monaco.contribution.d.ts && mcopy ./node_modules/@kusto/language-service/Kusto.JavaScript.Client.min.js  ./release/min/kusto.javascript.client.min.js && mcopy ./node_modules/@kusto/language-service-next/Kusto.Language.Bridge.min.js ./release/min/Kusto.Language.Bridge.min.js && mcopy ./node_modules/@kusto/language-service/bridge.min.js ./release/min/bridge.min.js && mcopy ./node_modules/@kusto/language-service/newtonsoft.json.min.js ./release/min/newtonsoft.json.min.js",
-        "prepublishOnly": "mkdirp release  && npm run compile && node ./scripts/release.js && node ./scripts/bundle.js && npm run copy_runtime_deps_to_out && npm run copy_types_to_release && npm run test_release",
+        "build_release": "mkdirp release  && npm run compile && node ./scripts/release.js && node ./scripts/bundle.js && npm run copy_runtime_deps_to_out && npm run copy_types_to_release && npm run test_release",
         "test": "jest",
         "clean": "mrmdir ./out && mrmdir ./release"
     },


### PR DESCRIPTION
### Summary
Now that there is a GitHub action NPM publish should do just publish. 
Running a server for local testing won't work on a GitHub action and the other operations that were done in npm publish are now executed in separated steps in the `NPMPublish` GitHub action. 
