### PR TITLE
add vscode-languageserver-textdocument

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "3.0.0-beta",
+  "version": "3.0.2-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6743,6 +6743,12 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+      "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==",
+      "dev": true
     },
     "vscode-languageserver-types": {
       "version": "3.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "3.0.1-beta",
+    "version": "3.0.2-beta",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"
@@ -50,6 +50,7 @@
         "ts-jest": "^26.1.1",
         "typescript": "3.9.7",
         "vscode-languageserver-types": "3.15.1",
+        "vscode-languageserver-textdocument": "1.0.1",
         "xregexp": "^3.2.0"
     },
     "dependencies": {


### PR DESCRIPTION
when using `ls.DocumentText`, VSCode presented it as obsolete and suggested to use `TextDoucment` from `vscode-languageserver-textdocument`. This PR is doing exactly that. 