### PR TITLE
Fix bug: Functions with default value were validated incorrectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ There are 2 APIs to set a Kusto schema:
 ## Changelog
 
 ### 3.1.0-beta.3
-- Validation of my Functions ignore default values.  
+- A function validation fails (shows squiggly red lines), if the function is defined with a parameter that has a default value, but it is used without passing a value for that parameter.
 
 ### 3.0.1
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ There are 2 APIs to set a Kusto schema:
 
 ## Changelog
 
+### 3.1.0-beta.3
+- Validation of my Functions ignore default values.  
+
 ### 3.0.1
 
 - Fix exception "Cannot read property 'getText' of null TypeError: Cannot read property 'getText' of null at e.parseDocumentV2"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,10 @@ There are 2 APIs to set a Kusto schema:
 
 ### 3.1.0-beta.4
 - A function validation fails (shows squiggly red lines), if the function is defined with a parameter that has a default value, but it is used without passing a value for that parameter.
-- Missing tokens are no longer added when formatting the queries. 
+- Fix bug: Scalars function parameters are always showing "Table expected" error with squiggly error red line when using setSchemaFromShowSchema.
+
+### 3.1.0-beta.3
+- Missing tokens are no longer added when formatting queries. 
 
 ### 3.0.1
 

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "3.1.0-beta.3",
+  "version": "3.1.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "3.1.0-beta.2",
+  "version": "3.1.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "3.1.0-beta.0",
+  "version": "3.1.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "3.1.0-beta.3",
+    "version": "3.1.0-beta.4",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "3.1.0-beta.2",
+    "version": "3.1.0-beta.3",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -783,7 +783,7 @@ class KustoLanguageService implements LanguageService {
                                       type: col.Type,
                                       cslType: col.CslType,
                                   }))
-                                : [],
+                                : inputParam.Columns as undefined | null | []
                         })),
                     })),
             }));

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -28,6 +28,8 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { FoldingRange } from 'vscode-languageserver-types';
 import * as XRegExp from 'xregexp';
 import k = Kusto.Data.IntelliSense;
+import parsing = Kusto.Language.Parsing;
+import syntax = Kusto.Language.Syntax;
 import k2 = Kusto.Language.Editor;
 import sym = Kusto.Language.Symbols;
 import GlobalState = Kusto.Language.GlobalState;
@@ -774,6 +776,7 @@ class KustoLanguageService implements LanguageService {
                             name: inputParam.Name,
                             type: inputParam.Type,
                             cslType: inputParam.CslType,
+                            cslDefaultValue: inputParam.CslDefaultValue,
                             columns: inputParam.Columns
                                 ? inputParam.Columns.map((col) => ({
                                       name: col.Name,
@@ -1489,7 +1492,29 @@ class KustoLanguageService implements LanguageService {
             const paramSymbol: sym.ScalarSymbol = Kusto.Language.Symbols.ScalarTypes.GetSymbol(
                 getCslTypeNameFromClrType(param.type)
             );
-            return new sym.Parameter.$ctor2(param.name, paramSymbol);
+
+            let expression;
+            if (param.cslDefaultValue && typeof param.cslDefaultValue === "string") {
+                const parser = parsing.QueryGrammar.From(Kusto.Language.GlobalState.Default).ConstantExpression;
+                expression = parsing.SyntaxParsers.ParseFirst<parsing.Parser$2<parsing.LexicalToken, syntax.Expression>>(
+                    { prototype: parser }, 
+                    parser, 
+                    param.cslDefaultValue);
+            }
+
+            return new sym.Parameter.$ctor3(
+                param.name,
+                paramSymbol,
+                null,
+                null,
+                null,
+                false,
+                null,
+                1,
+                1,
+                expression,
+                null
+            );
         }
 
         if (param.columns.length == 0) {

--- a/package/src/languageService/schema.ts
+++ b/package/src/languageService/schema.ts
@@ -15,6 +15,7 @@ export interface ScalarParameter {
     type?: string;
     cslType?: string;
     docstring?: string;
+    cslDefaultValue?: string;
 }
 
 // an input parameter either be a scalar in which case it has a name, type and cslType, or it can be columnar, in which case
@@ -158,6 +159,7 @@ export namespace showSchema {
         Type?: string;
         CslType?: string;
         DocString?: string;
+        CslDefaultValue?: string;
     }
 
     export type InputParameter = ScalarParameter & { Columns?: ScalarParameter[] };

--- a/package/src/monaco.d.ts
+++ b/package/src/monaco.d.ts
@@ -1,8 +1,8 @@
 // This file gets bundled as is with monaco-kusto.
 // Everything that needs to be exposed to consumers should be typed here.
 // This means that all declarations here are duplicated from the actual definitions around the code.
-// TODO: think about turning this around - have all other code depnedent on this file thus not needing the duplication.
-// this was done like this becuase that's the standard way all other monaco extentions work for some reason.
+// TODO: think about turning this around - have all other code dependent on this file thus not needing the duplication.
+// this was done like this because that's the standard way all other monaco extensions work for some reason.
 
 declare module monaco.editor {
     export interface ICodeEditor {
@@ -116,15 +116,18 @@ declare module monaco.languages.kusto {
     export interface Column {
         name: string;
         type: string;
+        docstring?: string;
     }
     export interface Table {
         name: string;
         columns: Column[];
+        docstring?: string;
     }
     export interface ScalarParameter {
         name: string;
         type?: string;
         cslType?: string;
+        cslDefaultValue?: string;
     }
 
     // an input parameter either be a scalar in which case it has a name, type and cslType, or it can be columnar, in which case
@@ -134,6 +137,7 @@ declare module monaco.languages.kusto {
     export interface Function {
         name: string;
         body: string;
+        docstring?: string;
         inputParameters: InputParameter[];
     }
     export interface Database {

--- a/package/test/custom_schema.json
+++ b/package/test/custom_schema.json
@@ -1478,7 +1478,33 @@
                     }
                 ],
                 "majorVersion": 0,
-                "functions": [],
+                "functions": [
+                    {
+                        "name": "myFunction1",
+                        "inputParameters": [],
+                        "body": "{     StormEvents     | limit 100 }  ",
+                        "folder": "Demo",
+                        "docString": "Simple demo function",
+                        "functionKind": "Unknown",
+                        "outputColumns": []
+                    },
+                    {
+                        "name": "myFunction2",
+                        "inputParameters": [
+                            {
+                                "name": "p",
+                                "type": "System.Int32",
+                                "cslType": "int",
+                                "cslDefaultValue": "6"
+                            }
+                        ],
+                        "body": "{     StormEvents     | limit myLimit }  ",
+                        "folder": "Demo",
+                        "docString": "Demo function with parameter",
+                        "functionKind": "Unknown",
+                        "outputColumns": []
+                    }
+                ],
                 "minorVersion": 0
             }
         ]
@@ -2958,7 +2984,33 @@
             }
         ],
         "majorVersion": 0,
-        "functions": [],
+        "functions": [
+            {
+                "name": "myFunction1",
+                "inputParameters": [],
+                "body": "{     StormEvents     | limit 100 }  ",
+                "folder": "Demo",
+                "docString": "Simple demo function",
+                "functionKind": "Unknown",
+                "outputColumns": []
+            },
+            {
+                "name": "myFunction2",
+                "inputParameters": [
+                    {
+                        "name": "p",
+                        "type": "System.Int32",
+                        "cslType": "int",
+                        "cslDefaultValue": "6"
+                    }
+                ],
+                "body": "{     StormEvents     | limit myLimit }  ",
+                "folder": "Demo",
+                "docString": "Demo function with parameter",
+                "functionKind": "Unknown",
+                "outputColumns": []
+            }
+        ],
         "minorVersion": 0
     }
 }

--- a/package/test/test.js
+++ b/package/test/test.js
@@ -233,6 +233,7 @@ fetch('./test/mode.txt')
                                             Type: 'System.Int64',
                                             CslType: 'long',
                                             DocString: 'Demo for a parameter',
+                                            CslDefaultValue: "6"
                                         },
                                     ],
                                     Body: '{     StormEvents     | limit myLimit }  ',

--- a/samples/react/src/schema.js
+++ b/samples/react/src/schema.js
@@ -76,6 +76,7 @@ const schema = {
               Type: "System.Int64",
               CslType: "long",
               DocString: "Demo for a parameter",
+              CslDefaultValue: "6"
             },
           ],
           Body: "{     StormEvents     | limit myLimit }  ",


### PR DESCRIPTION
### Summary

Function that has a default value, when written with no parameter shows an error. 

#### Before 
![image](https://user-images.githubusercontent.com/8294298/97674658-232db700-1a4b-11eb-8ee4-3df577c825cc.png)

#### After 

**Fixed when using `setSchema`:** 
![image](https://user-images.githubusercontent.com/8294298/97676957-b61c2080-1a4e-11eb-8e01-3b64bce50c5b.png)

 ### Other Information

@lidermanrony setSchemaFromShowSchema is still broken. setSchemaFromShowSchema is causing normalization (a call to `normalizeSchema`), and `normalizeSchema` always returns columns in the function's parameter. 
![image](https://user-images.githubusercontent.com/8294298/97675824-f7133580-1a4c-11eb-81be-19d38293335c.png)
 
This causes createParameter to always return a parameter of type Tabular:
![image](https://user-images.githubusercontent.com/8294298/97676463-eb743e80-1a4d-11eb-8d6e-daa40995f789.png)

Which causes the error "Table Expected" when scalars are used:
![image](https://user-images.githubusercontent.com/8294298/97675148-03e35980-1a4c-11eb-8f0e-c9e20b6a2886.png)

Because I don't understand the scenario here, I didn't fix the default values for setSchemaFromShowSchema, since the default value only works with scalars, and scalars are broken in this flow.
![image](https://user-images.githubusercontent.com/8294298/97676689-3b530580-1a4e-11eb-9e39-6cc26735bd32.png)

Why in `setSchemaFromShowSchema` the parameter is always defined as Tabular? 
