### PR TITLE
Match formatting settings to the default formatting settings in Kusto Explorer

### DIFF
--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -918,11 +918,12 @@ class KustoLanguageService implements LanguageService {
         }
 
         const formattedCommands = commands.map((command) => {
-            const formatter = Kusto.Language.Editor.FormattingOptions.Default.WithIndentationSize(0)
-                .WithInsertMissingTokens(true)
+            const formatter = Kusto.Language.Editor.FormattingOptions.Default
+                .WithIndentationSize(4)
+                .WithInsertMissingTokens(false)
                 .WithPipeOperatorStyle(Kusto.Language.Editor.PlacementStyle.NewLine)
-                .WithSemicolonStyle(Kusto.Language.Editor.PlacementStyle.None)
-                .WithBrackettingStyle(k2.BrackettingStyle.Vertical);
+                .WithSemicolonStyle(Kusto.Language.Editor.PlacementStyle.Smart)
+                .WithBrackettingStyle(k2.BrackettingStyle.Diagonal);
 
             if (rangeStart == null || rangeEnd == null || (rangeStart === command.Start && rangeEnd === command.End)) {
                 const result = command.Service.GetFormattedText(formatter);


### PR DESCRIPTION
### Summary

Remove "Insert Missing Token" option based on user feedback. Also match formatting settings to KE's default formatting settings.

Before formatting:
![image](https://user-images.githubusercontent.com/8294298/97689697-35aeed00-1a59-11eb-9335-a82701d65eb9.png)

After Formatting With "Insert Missing Token" (note how it adds token `;` and `database`):
![image](https://user-images.githubusercontent.com/8294298/97689798-58410600-1a59-11eb-964c-d1881f056cfc.png)

After Formatting Without "Insert Missing Token":
![image](https://user-images.githubusercontent.com/8294298/97689848-6858e580-1a59-11eb-9a8b-309cc63ed895.png)

 ### Other Information

Based on user feedback. See email thread "RE: Logs transition from Details results in broken query"