### PR TITLE
Bug Fix: Format query hangs in some use cases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,11 @@ There are 2 APIs to set a Kusto schema:
 
 ## Changelog
 
-### 3.1.0-beta.4
+### 3.2.1
+- Colorize public query options. 
+- Bug Fix: Format query hangs in some use cases.
+
+### 3.2.0
 - A function validation fails (shows squiggly red lines), if the function is defined with a parameter that has a default value, but it is used without passing a value for that parameter.
 - Fix bug: Scalars function parameters are always showing "Table expected" error with squiggly error red line when using setSchemaFromShowSchema.
 

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -741,9 +741,9 @@
       "integrity": "sha512-HBMASNCxtUe+BPOONpiXhzlCXuS0UIWl9YRrh521dTbEsoDwBN7Orlq6SUlDqKKdy7i4N4+7KtGFwwRjsgke7A=="
     },
     "@kusto/language-service-next": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/@kusto/language-service-next/-/language-service-next-0.0.37.tgz",
-      "integrity": "sha512-r/cieTEmRranKGDxPFFCmxFkQ5V8pfilDt/ib+JhEAMTjGjbAkpGFQaVgXd9RUa3aA9hF/ouDdhymcgCvzO52g=="
+      "version": "0.0.40",
+      "resolved": "https://registry.npmjs.org/@kusto/language-service-next/-/language-service-next-0.0.40.tgz",
+      "integrity": "sha512-vBaeiZTz97pZ2Dy1ImbzRzXalZCiXIA+7MSRPvtNmGIsoVvzdTBezQCogZL2btl5JWyUWEcpZBoHvR+iyhSsaQ=="
     },
     "@sinonjs/commons": {
       "version": "1.8.0",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"
@@ -55,7 +55,7 @@
     },
     "dependencies": {
         "@kusto/language-service": "2.0.0-beta.0",
-        "@kusto/language-service-next": "0.0.37"
+        "@kusto/language-service-next": "0.0.40"
     },
     "peerDependencies": {
         "monaco-editor": "^0.20.0"

--- a/package/src/languageFeatures.ts
+++ b/package/src/languageFeatures.ts
@@ -236,6 +236,7 @@ const classificationToColorLight: { [K in kinds]: string } = {
     ClientParameter: 'b5cea8',
     SchemaMember: 'C71585',
     SignatureParameter: '2B91AF',
+    Option: '000000',
 };
 
 const classificationToColorDark: { [K in kinds]: string } = {
@@ -263,6 +264,7 @@ const classificationToColorDark: { [K in kinds]: string } = {
     ClientParameter: 'b5cea8',
     SchemaMember: '4ec9b0',
     SignatureParameter: '2B91AF',
+    Option: 'd4d4d4',
 };
 
 export class ColorizationAdapter {

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -241,6 +241,7 @@ class KustoLanguageService implements LanguageService {
         [k2.CompletionKind.TabularSuffix]: k.OptionKind.None,
         [k2.CompletionKind.Unknown]: k.OptionKind.None,
         [k2.CompletionKind.Variable]: k.OptionKind.Parameter,
+        [k2.CompletionKind.Option]: k.OptionKind.Option,
     };
 
     constructor(schema: s.EngineSchema, languageSettings: LanguageSettings) {
@@ -1498,8 +1499,8 @@ class KustoLanguageService implements LanguageService {
             if (param.cslDefaultValue && typeof param.cslDefaultValue === "string") {
                 const parser = parsing.QueryGrammar.From(Kusto.Language.GlobalState.Default).ConstantExpression;
                 expression = parsing.SyntaxParsers.ParseFirst<parsing.Parser$2<parsing.LexicalToken, syntax.Expression>>(
-                    { prototype: parser }, 
-                    parser, 
+                    { prototype: parser },
+                    parser,
                     param.cslDefaultValue);
             }
 
@@ -1963,6 +1964,7 @@ class KustoLanguageService implements LanguageService {
         [k2.CompletionKind.TabularSuffix]: ls.CompletionItemKind.Field,
         [k2.CompletionKind.Unknown]: ls.CompletionItemKind.Interface,
         [k2.CompletionKind.Variable]: ls.CompletionItemKind.Variable,
+        [k2.CompletionKind.Option]: ls.CompletionItemKind.Text,
     };
 
     private kustoKindToLsKind(kustoKind: k.OptionKind): ls.CompletionItemKind {


### PR DESCRIPTION
Integrate 2 changes from Kusto.Language:
1. Bug Fix: Formatter was hanging in some use cases.
2. Allow colorize public query options. For now just keep it black. 
    light: 
    ![image](https://user-images.githubusercontent.com/8294298/98737619-49acf580-235b-11eb-8fa3-b4e9a3c95f90.png)
    dark: 
    ![image](https://user-images.githubusercontent.com/8294298/98737658-5b8e9880-235b-11eb-96a3-a50d67b9d471.png)







