### PR TITLE
Fix intellisense bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ There are 2 APIs to set a Kusto schema:
 
 ## Changelog
 
+### 3.2.3
+- Bug fix: Intellisense doesn't show columns when using this syntax `materialized_view("<table name>") | where ` 
+
+### 3.2.2
+- Bug Fix: In `mv-expand kind=array` kind is shown with a squiggly error line
+- Update @kusto/language-service-next
+
 ### 3.2.1
 - Colorize public query options. 
 - Bug Fix: Format query hangs in some use cases.

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -741,9 +741,9 @@
       "integrity": "sha512-HBMASNCxtUe+BPOONpiXhzlCXuS0UIWl9YRrh521dTbEsoDwBN7Orlq6SUlDqKKdy7i4N4+7KtGFwwRjsgke7A=="
     },
     "@kusto/language-service-next": {
-      "version": "0.0.40",
-      "resolved": "https://registry.npmjs.org/@kusto/language-service-next/-/language-service-next-0.0.40.tgz",
-      "integrity": "sha512-vBaeiZTz97pZ2Dy1ImbzRzXalZCiXIA+7MSRPvtNmGIsoVvzdTBezQCogZL2btl5JWyUWEcpZBoHvR+iyhSsaQ=="
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@kusto/language-service-next/-/language-service-next-0.0.41.tgz",
+      "integrity": "sha512-LSpLiw9admWQvKxT0wrd9MwiwfhjoIVMIU0CTG40UP5qJHo9DJHNeu3OZ3yM3fDnWQ69+DvXpUXsOcLyQB2CYw=="
     },
     "@sinonjs/commons": {
       "version": "1.8.0",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "3.2.1",
+    "version": "3.2.3",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"
@@ -55,7 +55,7 @@
     },
     "dependencies": {
         "@kusto/language-service": "2.0.0-beta.0",
-        "@kusto/language-service-next": "0.0.40"
+        "@kusto/language-service-next": "0.0.41"
     },
     "peerDependencies": {
         "monaco-editor": "^0.20.0"

--- a/package/src/languageService/schema.ts
+++ b/package/src/languageService/schema.ts
@@ -7,6 +7,7 @@ export interface Column {
 }
 export interface Table {
     name: string;
+    entityType?: TableEntityType;
     columns: Column[];
     docstring?: string;
 }
@@ -47,6 +48,8 @@ export interface EngineSchema {
     database: Database | undefined; // a reference to the database that's in current context.
     globalParameters?: ScalarParameter[];
 }
+
+export type TableEntityType = 'Table' | 'ExternalTable' | 'MaterializedViewTable';
 
 export interface ClusterMangerSchema {
     clusterType: 'ClusterManager';
@@ -146,6 +149,7 @@ export namespace showSchema {
 
     export interface Table {
         Name: string;
+        EntityType: TableEntityType,
         OrderedColumns: Column[];
         DocString?: string;
     }

--- a/package/test/test.js
+++ b/package/test/test.js
@@ -214,6 +214,22 @@ fetch('./test/mode.txt')
                                         },
                                     ],
                                 },
+                                MaterializedViewExamples: {
+                                    Name: 'MaterializedViewExamples',
+                                    EntityType: 'MaterializedViewTable',
+                                    OrderedColumns: [
+                                        {
+                                            Name: 'MVTimestamp',
+                                            Type: 'System.DateTime',
+                                            CslType: 'datetime',
+                                        },
+                                        {
+                                            Name: 'MVRequestCount',
+                                            Type: 'System.Int64',
+                                            CslType: 'long',
+                                        },
+                                    ],
+                                }
                             },
                             Functions: {
                                 MyFunction1: {
@@ -331,7 +347,7 @@ fetch('./test/mode.txt')
                             },
                         },
                     },
-                };
+                }; 
                 window.setHelp = () =>
                     monaco.languages.kusto.getKustoWorker().then((workerAccessor) => {
                         const model = editor.getModel();


### PR DESCRIPTION
**Bug fix: Intellisense doesn't show columns when using this syntax `materialized_view("<table name>") | where `**
Root cause: table's type  (Materialized / External / Table ) hasn't passed to the transpiled c# code. 

2. In `mv-expand kind=array` kind is shown with a squiggly error line
Root cause: kind is a new alias to bagexpansion. The alias was added in the latest version of @kusto/language-service-next

### Summary

![image](https://user-images.githubusercontent.com/8294298/101636924-dab9cf80-39e0-11eb-817f-2882b6980d48.png)
