### PR TITLE
Expose formatting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ There are 2 APIs to set a Kusto schema:
 
 ## Changelog
 
+### 3.2.5
+- Expose formatting options
+
 ### 3.2.4
 - Bug fix: `union *` is auto-formatted into `union*`
 

--- a/package/index.html
+++ b/package/index.html
@@ -30,6 +30,10 @@
             <button onclick="setSemanticOn()">Semantic colorization On</button>
         </div>
         <div>
+            <button onclick="setNewLineFormatting()">Set New Line Formatting</button>
+            <button onclick="setSmartFormatting()">Set Smart Formatting</button>
+        </div>
+        <div>
             <button onclick="setIntellisenseV1()">V1 Intellisense</button>
             <button onclick="setIntellisenseV2()">V2 Intellisense</button>
         </div>

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "3.2.4",
+    "version": "3.2.5-rc1",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "3.2.5-rc1",
+    "version": "3.2.5",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/kustoWorker.ts
+++ b/package/src/kustoWorker.ts
@@ -1,6 +1,7 @@
 import IWorkerContext = monaco.worker.IWorkerContext;
 
 import * as kustoService from './languageService/kustoLanguageService';
+import { LanguageSettings } from './languageService/settings';
 import { Schema, showSchema, ScalarParameter } from './languageService/schema';
 import * as ls from 'vscode-languageserver-types';
 import { ColorizationRange } from './languageService/kustoLanguageService';
@@ -13,7 +14,7 @@ export class KustoWorker {
     private _ctx: IWorkerContext;
     private _languageService: kustoService.LanguageService;
     private _languageId: string;
-    private _languageSettings: kustoService.LanguageSettings;
+    private _languageSettings: LanguageSettings;
 
     constructor(ctx: IWorkerContext, createData: ICreateData) {
         this._ctx = ctx;
@@ -260,7 +261,7 @@ export class KustoWorker {
 
 export interface ICreateData {
     languageId: string;
-    languageSettings: kustoService.LanguageSettings;
+    languageSettings: LanguageSettings;
 }
 
 export function create(ctx: IWorkerContext, createData: ICreateData): KustoWorker {

--- a/package/src/languageService/settings.ts
+++ b/package/src/languageService/settings.ts
@@ -1,0 +1,19 @@
+export interface LanguageSettings {
+    includeControlCommands?: boolean;
+    newlineAfterPipe?: boolean;
+    openSuggestionDialogAfterPreviousSuggestionAccepted?: boolean;
+    useIntellisenseV2: boolean;
+    useSemanticColorization?: boolean;
+    useTokenColorization?: boolean;
+    disabledCompletionItems?: string[];
+    onDidProvideCompletionItems?: monaco.languages.kusto.OnDidProvideCompletionItems;
+    enableHover?: boolean;
+    formatter?: FormatterOptions;
+}
+
+export interface FormatterOptions {
+    indentationSize?: number;
+    pipeOperatorStyle?: FormatterPlacementStyle;
+}
+
+export type FormatterPlacementStyle = 'None' | 'NewLine' | 'Smart';

--- a/package/src/monaco.contribution.ts
+++ b/package/src/monaco.contribution.ts
@@ -14,7 +14,7 @@ declare var require: <T>(moduleId: [string], callback: (module: T) => void) => v
 export class LanguageServiceDefaultsImpl implements monaco.languages.kusto.LanguageServiceDefaults {
     private _onDidChange = new Emitter<monaco.languages.kusto.LanguageServiceDefaults>();
     private _languageSettings: monaco.languages.kusto.LanguageSettings;
-    // in miliseconds. For example - this is 2 minutes 2 * 60 * 1000
+    // in milliseconds. For example - this is 2 minutes 2 * 60 * 1000
     private _workerMaxIdleTime: number;
 
     constructor(languageSettings: monaco.languages.kusto.LanguageSettings) {
@@ -60,6 +60,10 @@ const defaultLanguageSettings: monaco.languages.kusto.LanguageSettings = {
     useSemanticColorization: true,
     useTokenColorization: true,
     enableHover: true,
+    formatter: {
+        indentationSize: 4,
+        pipeOperatorStyle: 'Smart'
+    }
 };
 
 const kustoDefaults = new LanguageServiceDefaultsImpl(defaultLanguageSettings);

--- a/package/src/monaco.d.ts
+++ b/package/src/monaco.d.ts
@@ -21,7 +21,15 @@ declare module monaco.languages.kusto {
         disabledCompletionItems?: string[];
         onDidProvideCompletionItems?: monaco.languages.kusto.OnDidProvideCompletionItems;
         enableHover?: boolean;
+        formatter?: FormatterOptions;
     }
+
+    export interface FormatterOptions {
+        indentationSize?: number;
+        pipeOperatorStyle?: FormatterPlacementStyle;
+    }
+    
+    export type FormatterPlacementStyle = 'None' | 'NewLine' | 'Smart';
 
     export interface LanguageServiceDefaults {
         readonly onDidChange: IEvent<LanguageServiceDefaults>;

--- a/package/test/test.js
+++ b/package/test/test.js
@@ -374,13 +374,25 @@ fetch('./test/mode.txt')
                 window.setSemanticOff = () =>
                     monaco.languages.kusto.getKustoWorker().then((workerAccessor) => {
                         const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
-                        monaco.useSemanticColorization = false;
+                        monacoSettings.useSemanticColorization = false;
+                        monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
+                    });
+                window.setNewLineFormatting = () =>
+                    monaco.languages.kusto.getKustoWorker().then((workerAccessor) => {
+                        const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
+                        monacoSettings.formatter.pipeOperatorStyle = 'NewLine';
+                        monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
+                    });
+                window.setSmartFormatting = () =>
+                    monaco.languages.kusto.getKustoWorker().then((workerAccessor) => {
+                        const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
+                        monacoSettings.formatter.pipeOperatorStyle = 'Smart';
                         monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
                     });
                 window.setSemanticOn = () =>
                     monaco.languages.kusto.getKustoWorker().then((workerAccessor) => {
                         const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
-                        monaco.useSemanticColorization = true;
+                        monacoSettings.useSemanticColorization = true;
                         monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
                     });
                 window.setIntellisenseV1 = () =>


### PR DESCRIPTION
### Summary

A Log Analytics user complained that the Smart pipe formatting doesn't match his own personal taste. This change allows users to set the required formatting settings.   

 ### Other Information

Usage: 
```typescript
const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
if (monacoSettings.formatting.pipeOperatorStyle === 'NewLine') {
    return;
}

monacoSettings.formatter = { pipeOperatorStyle: "NewLine" };
monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
```