### PR TITLE
fix: errors are displayed twice on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ There are 2 APIs to set a Kusto schema:
 
 ## Changelog
 
+### 3.2.6
+- fix: errors are shown twice on hover.
 ### 3.2.5
 - Expose formatting options
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "3.2.5",
+    "version": "3.2.6",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -1282,13 +1282,26 @@ class KustoLanguageService implements LanguageService {
 
         const quickInfo = currentBLock.Service.GetQuickInfo(cursorOffset);
 
-        if (!quickInfo || !quickInfo.Text) {
+        if (!quickInfo || !quickInfo.Items) {
             return Promise.resolve(undefined);
         }
 
+        let items = this.toArray(quickInfo.Items)
+
+        if (!items) {
+            return Promise.resolve(undefined);
+        }
+        
+        // Errors are already shown in getDiagnostics. we don't want them in doHover.
+        items = items.filter(item => item.Kind !== k2.QuickInfoKind.Error )
+        const itemsText = items.map(item => item.Text.replace('\n\n', '\n* * *\n'));
+        // separate items by horizontal line.
+        const text = itemsText.join("\n* * *\n");
+
+
         // Instead of just an empty line between the first line (the signature) and the second line (the description)
         // add an horizontal line (* * * in markdown) between them.
-        return Promise.resolve({ contents: quickInfo.Text.replace('\n\n', '\n* * *\n') });
+        return Promise.resolve({ contents: text });
     }
 
     //#region dummy schema for manual testing


### PR DESCRIPTION
### Summary
fix issue where errors are shown twice on hover
 <!--

 Link to the issue describing the bug that you're fixing.

 Provide a general description of the code changes in your pull request.

 -->

 ### Other Information

 <!--

 If there's anything else that's important and relevant to your pull request, mention that information here.

 -->