### PR TITLE
Added null values to render options type

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ There are 2 APIs to set a Kusto schema:
 
 ## Changelog
 
+### 3.2.8
+- fix: `RenderOptions` type missing `null` property union variants
 ### 3.2.7
 - fix: errors are shown twice on hover
 ### 3.2.6

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "3.2.7",
+    "version": "3.2.8",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/kustoWorker.ts
+++ b/package/src/kustoWorker.ts
@@ -41,14 +41,14 @@ export class KustoWorker {
         return this._languageService.getSchema();
     }
 
-    getCommandInContext(uri: string, cursorOffest: number): Promise<string | null> {
+    getCommandInContext(uri: string, cursorOffset: number): Promise<string | null> {
         const document = this._getTextDocument(uri);
         if (!document) {
             console.error(`getCommandInContext: document is ${document}. uri is ${uri}`);
             return null;
         }
 
-        const commandInContext = this._languageService.getCommandInContext(document, cursorOffest);
+        const commandInContext = this._languageService.getCommandInContext(document, cursorOffset);
         if (commandInContext === undefined) {
             return null;
         }
@@ -56,14 +56,14 @@ export class KustoWorker {
         return commandInContext;
     }
 
-    getQueryParams(uri: string, cursorOffest: number): Promise<{ name: string; type: string }[]> {
+    getQueryParams(uri: string, cursorOffset: number): Promise<{ name: string; type: string }[]> {
         const document = this._getTextDocument(uri);
         if (!document) {
             console.error(`getQueryParams: document is ${document}. uri is ${uri}`);
             return null;
         }
 
-        const queryParams = this._languageService.getQueryParams(document, cursorOffest);
+        const queryParams = this._languageService.getQueryParams(document, cursorOffset);
         if (queryParams === undefined) {
             return null;
         }
@@ -117,7 +117,7 @@ export class KustoWorker {
     }
 
     /**
-     * Get command in cotext and the command range.
+     * Get command in context and the command range.
      * This method will basically convert generate microsoft language service interface to monaco interface.
      * @param uri document URI
      * @param cursorOffset offset from start of document to cursor

--- a/package/src/languageService/renderInfo.ts
+++ b/package/src/languageService/renderInfo.ts
@@ -21,22 +21,22 @@ export declare type YSplit = 'none' | 'axes' | 'panels';
 export declare type Kind = 'default' | 'unstacked' | 'stacked' | 'stacked100' | 'map';
 
 export interface RenderOptions {
-    visualization?: VisualizationType;
-    title?: string;
-    xcolumn?: string;
-    series?: string[];
-    ycolumns?: string[];
-    xtitle?: string;
-    ytitle?: string;
-    xaxis?: Scale;
-    yaxis?: Scale;
-    legend?: LegendVisibility;
-    ySplit?: YSplit;
-    accumulate?: boolean;
-    kind?: Kind;
-    anomalycolumns?: string[];
-    ymin?: number;
-    ymax?: number;
+    visualization?: null | VisualizationType;
+    title?: null | string;
+    xcolumn?: null | string;
+    series?: null | string[];
+    ycolumns?: null | string[];
+    xtitle?: null | string;
+    ytitle?: null | string;
+    xaxis?: null | Scale;
+    yaxis?: null | Scale;
+    legend?: null | LegendVisibility;
+    ySplit?: null | YSplit;
+    accumulate?: null | boolean;
+    kind?: null | Kind;
+    anomalycolumns?: null | string[];
+    ymin?: null | number;
+    ymax?: null | number;
 }
 
 export interface RenderInfo {

--- a/package/src/monaco.d.ts
+++ b/package/src/monaco.d.ts
@@ -203,22 +203,22 @@ declare module monaco.languages.kusto {
     export declare type Kind = 'default' | 'unstacked' | 'stacked' | 'stacked100' | 'map';
 
     export interface RenderOptions {
-        visualization?: VisualizationType;
-        title?: string;
-        xcolumn?: string;
-        series?: string[];
-        ycolumns?: string[];
-        xtitle?: string;
-        ytitle?: string;
-        xaxis?: Scale;
-        yaxis?: Scale;
-        legend?: LegendVisibility;
-        ySplit?: YSplit;
-        accumulate?: boolean;
-        kind?: Kind;
-        anomalycolumns?: string[];
-        ymin?: number;
-        ymax?: number;
+        visualization?: null | VisualizationType;
+        title?: null | string;
+        xcolumn?: null | string;
+        series?: null | string[];
+        ycolumns?: null | string[];
+        xtitle?: null | string;
+        ytitle?: null | string;
+        xaxis?: null | Scale;
+        yaxis?: null | Scale;
+        legend?: null | LegendVisibility;
+        ySplit?: null | YSplit;
+        accumulate?: null | boolean;
+        kind?: null | Kind;
+        anomalycolumns?: null | string[];
+        ymin?: null | number;
+        ymax?: null | number;
     }
 
     export interface RenderInfo {


### PR DESCRIPTION
### Summary

Render options taken off of a `KustoWorker` can be `null`.

https://dataexplorer.azure.com/clusters/help/databases/Samples?query=H4sIAAAAAAAAAwsuyS/KdS1LzSsp5qpRKEnMTlUwNACyilLzUlKLFAoyU5MzEotKFMozSzIUNEoyS3JSbRUy80o08kpzcjR1FIpTizJTixWQxBQ0AZCtENBUAAAA

```kql
StormEvents
| take 10
| render piechart with (title= int(null), series = int(null) )
```