### PR TITLE
Support syntax error messages as markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ There are 2 APIs to set a Kusto schema:
 
 ## Changelog
 
+### 3.2.10
+
+- feat: expose custom syntax error message options
+
 ### 3.2.9
 
 - feat: update language service to support python code strings

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "3.2.9",
+    "version": "3.2.10",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/languageFeatures.ts
+++ b/package/src/languageFeatures.ts
@@ -121,14 +121,12 @@ export class DiagnosticsAdapter {
             .then((worker) => {
                 return worker.doValidation(resource.toString(), intervals);
             })
-            .then((diagnostics) => {                
+            .then((diagnostics) => {
                 const newModel = monaco.editor.getModel(resource);
                 const versionId = newModel.getVersionId();
-                
                 if (versionId !== versionNumberBefore) {
                     return;
                 }
-                
                 const markers = diagnostics.map((d) => toDiagnostics(resource, d));
                 let model = monaco.editor.getModel(resource);
                 if (model && model.getModeId() === languageId) {
@@ -162,9 +160,9 @@ export class DiagnosticsAdapter {
 
                         // Remove previous syntax error decorations and set the new decorations
                         const oldDecorations = model.getAllDecorations()
-                        .filter(decoration => decoration.options.className == "squiggly-error")
-                        .map(decoration => decoration.id);
-                        
+                                                .filter(decoration => decoration.options.className == "squiggly-error")
+                                                .map(decoration => decoration.id);
+
                         model.deltaDecorations(oldDecorations, newDecorations);
                     }
                 }

--- a/package/src/languageService/settings.ts
+++ b/package/src/languageService/settings.ts
@@ -9,11 +9,18 @@ export interface LanguageSettings {
     onDidProvideCompletionItems?: monaco.languages.kusto.OnDidProvideCompletionItems;
     enableHover?: boolean;
     formatter?: FormatterOptions;
+    syntaxErrorAsMarkDown?: SyntaxErrorAsMarkDownOptions;
 }
 
 export interface FormatterOptions {
     indentationSize?: number;
     pipeOperatorStyle?: FormatterPlacementStyle;
+}
+
+export interface SyntaxErrorAsMarkDownOptions {
+    header?: string;
+    icon?: string;
+    enableSyntaxErrorAsMarkDown?: boolean;
 }
 
 export type FormatterPlacementStyle = 'None' | 'NewLine' | 'Smart';

--- a/package/src/monaco.contribution.ts
+++ b/package/src/monaco.contribution.ts
@@ -63,7 +63,10 @@ const defaultLanguageSettings: monaco.languages.kusto.LanguageSettings = {
     formatter: {
         indentationSize: 4,
         pipeOperatorStyle: 'Smart'
-    }
+    },
+    syntaxErrorAsMarkDown: {
+        enableSyntaxErrorAsMarkDown: false
+    }
 };
 
 const kustoDefaults = new LanguageServiceDefaultsImpl(defaultLanguageSettings);

--- a/package/src/monaco.d.ts
+++ b/package/src/monaco.d.ts
@@ -14,6 +14,7 @@ declare module monaco.languages.kusto {
     export interface LanguageSettings {
         includeControlCommands?: boolean;
         newlineAfterPipe?: boolean;
+        syntaxErrorAsMarkDown?: SyntaxErrorAsMarkDownOptions;
         openSuggestionDialogAfterPreviousSuggestionAccepted?: boolean;
         useIntellisenseV2?: boolean;
         useSemanticColorization?: boolean;
@@ -22,6 +23,12 @@ declare module monaco.languages.kusto {
         onDidProvideCompletionItems?: monaco.languages.kusto.OnDidProvideCompletionItems;
         enableHover?: boolean;
         formatter?: FormatterOptions;
+    }
+
+    export interface SyntaxErrorAsMarkDownOptions {
+        header?: string;
+        icon?: string;
+        enableSyntaxErrorAsMarkDown?: boolean;
     }
 
     export interface FormatterOptions {


### PR DESCRIPTION
### Summary
Add support in markdown for syntax error instead of plain text + option to add an header and an icon to the syntax error popup:

Before:
![image](https://user-images.githubusercontent.com/29915265/120098136-dcb54d80-c13c-11eb-9b50-f87a8889be98.png)


After:
![image](https://user-images.githubusercontent.com/29915265/120098148-efc81d80-c13c-11eb-9a8f-37a214aa327d.png)

![image](https://user-images.githubusercontent.com/29915265/120098080-952ec180-c13c-11eb-904b-a16af308df1b.png)

![image](https://user-images.githubusercontent.com/29915265/120098109-b5f71700-c13c-11eb-821f-d2ca8e52bc70.png)

![image](https://user-images.githubusercontent.com/29915265/120098120-c60ef680-c13c-11eb-941c-020ea3aa0116.png)


 <!--

 Link to the issue describing the bug that you're fixing.

 Provide a general description of the code changes in your pull request.

 -->

 ### Other Information

 <!--

 If there's anything else that's important and relevant to your pull request, mention that information here.

 -->