### PR TITLE
Add tests for syntaxErrorAsMarkDown setting

### DIFF
--- a/package/index.html
+++ b/package/index.html
@@ -30,6 +30,10 @@
             <button onclick="setSemanticOn()">Semantic colorization On</button>
         </div>
         <div>
+            <button onclick="enableSyntaxErrorAsMarkDown()">Enable syntax error as markdown</button>
+            <button onclick="disableSyntaxErrorAsMarkDown()">Disable syntax error as markdown</button>
+        </div>
+        <div>
             <button onclick="setNewLineFormatting()">Set New Line Formatting</button>
             <button onclick="setSmartFormatting()">Set Smart Formatting</button>
         </div>

--- a/package/test/test.js
+++ b/package/test/test.js
@@ -389,6 +389,21 @@ fetch('./test/mode.txt')
                         monacoSettings.formatter.pipeOperatorStyle = 'Smart';
                         monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
                     });
+                window.enableSyntaxErrorAsMarkDown = () => {
+                    const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
+                    monacoSettings.syntaxErrorAsMarkDown = {
+                        enableSyntaxErrorAsMarkDown: true,
+                        header: "Error"
+                    };
+                    monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
+                };
+                window.disableSyntaxErrorAsMarkDown = () => {
+                    const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;
+                    monacoSettings.syntaxErrorAsMarkDown = {
+                        enableSyntaxErrorAsMarkDown: false
+                    };
+                    monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
+                };
                 window.setSemanticOn = () =>
                     monaco.languages.kusto.getKustoWorker().then((workerAccessor) => {
                         const monacoSettings = monaco.languages.kusto.kustoDefaults.languageSettings;


### PR DESCRIPTION
### Summary

 <!--

 Link to the issue describing the bug that you're fixing.

 Provide a general description of the code changes in your pull request.

 -->

Add enableSyntaxErrorAsMarkDown and disableSyntaxErrorAsMarkDown options to test.js 
Fix code to enable changing this setting dynamically 
Fix bug when syntaxErrorAsMarkDown didn't show the red dot on overviewRuler (as regular syntax error does)