### PR TITLE
use specific monaco instance instead of global

### DIFF
--- a/package/.gitignore
+++ b/package/.gitignore
@@ -1,4 +1,4 @@
-/node_modules/
+**/node_modules/
 /out/
 /release/
 /src/**/*.js.map

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "3.2.12",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/workerManager.ts
+++ b/package/src/workerManager.ts
@@ -17,7 +17,7 @@ export class WorkerManager {
     private _worker: monaco.editor.MonacoWebWorker<KustoWorker>;
     private _client: Promise<KustoWorker>;
 
-    constructor(defaults: LanguageServiceDefaultsImpl) {
+    constructor(private _monacoInstance: typeof monaco, defaults: LanguageServiceDefaultsImpl) {
         this._defaults = defaults;
         this._worker = null;
         this._idleCheckInterval = self.setInterval(() => this._checkIfIdle(), 30 * 1000);
@@ -70,7 +70,7 @@ export class WorkerManager {
         const { onDidProvideCompletionItems, ...languageSettings } = this._defaults.languageSettings;
 
         if (!this._client) {
-            this._worker = monaco.editor.createWebWorker<KustoWorker>({
+            this._worker = this._monacoInstance.editor.createWebWorker<KustoWorker>({
                 // module that exports the create() method and returns a `KustoWorker` instance
                 moduleId: 'vs/language/kusto/kustoWorker',
 


### PR DESCRIPTION
### Summary

the package used the global window monaco. 
in case that different monaco instance is loaded (override the global monaco) there is a mixed between the two instances 

keep the monaco instance in local variable.

 