### PR TITLE
avoid kusto format/highlight on other language

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/commandFormatter.ts
+++ b/package/src/commandFormatter.ts
@@ -1,5 +1,4 @@
 export default class KustoCommandFormatter {
-    private cursorPosition: monaco.Position;
     private actionAdded: boolean = false;
 
     constructor(private editor: monaco.editor.IStandaloneCodeEditor) {
@@ -9,7 +8,6 @@ export default class KustoCommandFormatter {
             if (this.editor.getModel().getModeId() !== 'kusto') {
                 return;
             }
-            this.cursorPosition = changeEvent.selection.getStartPosition();
             // Theoretically you would expect this code to run only once in onDidCreateEditor.
             // Turns out that onDidCreateEditor is fired before the IStandaloneEditor is completely created (it is emmited by
             // the super ctor before the child ctor was able to fully run).

--- a/package/src/commandFormatter.ts
+++ b/package/src/commandFormatter.ts
@@ -6,6 +6,9 @@ export default class KustoCommandFormatter {
         // selection also represents no selection - for example the event gets triggered when moving cursor from point
         // a to point b. in the case start position will equal end position.
         editor.onDidChangeCursorSelection(changeEvent => {
+            if (this.editor.getModel().getModeId() !== 'kusto') {
+                return;
+            }
             this.cursorPosition = changeEvent.selection.getStartPosition();
             // Theoretically you would expect this code to run only once in onDidCreateEditor.
             // Turns out that onDidCreateEditor is fired before the IStandaloneEditor is completely created (it is emmited by

--- a/package/src/commandHighlighter.ts
+++ b/package/src/commandHighlighter.ts
@@ -17,7 +17,10 @@ export default class KustoCommandHighlighter implements monaco.editor.IEditorCon
         // Note that selection update is triggered not only for selection changes, but also just when no text selection is occuring and cursor just moves around.
         // This case is counted as a 0-length selection starting and ending on the cursor position.
         this.editor.onDidChangeCursorSelection(changeEvent => {
-           
+            if (this.editor.getModel().getModeId() !== 'kusto') {
+                return;
+            }
+
             this.highlightCommandUnderCursor(changeEvent);
         })
     }
@@ -32,7 +35,7 @@ export default class KustoCommandHighlighter implements monaco.editor.IEditorCon
     private highlightCommandUnderCursor(changeEvent: monaco.editor.ICursorSelectionChangedEvent): void {
             // Looks like the user selected a bunch of text. we don't want to highlight the entire command in this case - since highlighting
             // the text is more helpful.
-            if (!changeEvent.selection.isEmpty() || this.editor.getModel().getModeId() !== 'kusto') {
+            if (!changeEvent.selection.isEmpty()) {
                 this.decorations = this.editor.deltaDecorations(this.decorations, []);
                 return;
             }

--- a/package/src/commandHighlighter.ts
+++ b/package/src/commandHighlighter.ts
@@ -17,6 +17,7 @@ export default class KustoCommandHighlighter implements monaco.editor.IEditorCon
         // Note that selection update is triggered not only for selection changes, but also just when no text selection is occuring and cursor just moves around.
         // This case is counted as a 0-length selection starting and ending on the cursor position.
         this.editor.onDidChangeCursorSelection(changeEvent => {
+           
             this.highlightCommandUnderCursor(changeEvent);
         })
     }
@@ -31,7 +32,7 @@ export default class KustoCommandHighlighter implements monaco.editor.IEditorCon
     private highlightCommandUnderCursor(changeEvent: monaco.editor.ICursorSelectionChangedEvent): void {
             // Looks like the user selected a bunch of text. we don't want to highlight the entire command in this case - since highlighting
             // the text is more helpful.
-            if (!changeEvent.selection.isEmpty()) {
+            if (!changeEvent.selection.isEmpty() || this.editor.getModel().getModeId() !== 'kusto') {
                 this.decorations = this.editor.deltaDecorations(this.decorations, []);
                 return;
             }


### PR DESCRIPTION
### Summary

make sure that commandHighlighter & commandFormatter logic is done only on kusto language model

For example command Highlighting shouldn't be done on SQL editor.
