### PR TITLE
feat: add API to support cross-cluster-queries

### DIFF
--- a/package/index.html
+++ b/package/index.html
@@ -57,6 +57,8 @@
             <button onclick="getGlobalParams()">Show all global params</button>
             <button onclick="getReferencedGlobalParams()">Show Refernced global params</button>
             <button onclick="getRenderInfo()">Show Visualization Options</button>
+            <button onclick="getDatabaseReferences()">Get Database References</button>
+            <button onclick="getClusterReferences()">Get Cluster References</button>
         </div>
         <div>
             <button onclick="checkOnDidProvideCompletionItems()">onDidProvideCompletionItems</button>

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "4.0.6",
+    "version": "4.1.0",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"
@@ -22,7 +22,7 @@
         "watch": "echo dev > test/mode.txt && tsc -p ./src/tsconfig.watch.json && npm run copy_runtime_deps_to_out && concurrently \"live-server ./ \" \"tsc -w -p ./src/tsconfig.watch.json \"",
         "test_release": "echo release > test/mode.txt && http-server -c-1 -p 8080 ./ -o index.html",
         "copy_types_to_release": "mcopy ./src/monaco.d.ts ./release/esm/monaco.d.ts && mcopy ./out/amd/monaco.contribution.d.ts ./release/esm/monaco.contribution.d.ts && mcopy ./src/monaco.d.ts ./release/min/monaco.d.ts && mcopy ./out/amd/monaco.contribution.d.ts ./release/min/monaco.contribution.d.ts && mcopy ./node_modules/@kusto/language-service/Kusto.JavaScript.Client.min.js  ./release/min/kusto.javascript.client.min.js && mcopy ./node_modules/@kusto/language-service-next/Kusto.Language.Bridge.min.js ./release/min/Kusto.Language.Bridge.min.js && mcopy ./node_modules/@kusto/language-service/bridge.min.js ./release/min/bridge.min.js && mcopy ./node_modules/@kusto/language-service/newtonsoft.json.min.js ./release/min/newtonsoft.json.min.js",
-        "prepublishOnly": "mkdirp release  && npm run compile && node ./scripts/release.js && node ./scripts/bundle.js && npm run copy_runtime_deps_to_out && npm run copy_types_to_release",
+        "prepublishOnly": "mkdirp release  && yarn run compile && node ./scripts/release.js && node ./scripts/bundle.js && yarn run copy_runtime_deps_to_out && yarn run copy_types_to_release",
         "test": "jest",
         "clean": "mrmdir ./out && mrmdir ./release"
     },

--- a/package/package.json
+++ b/package/package.json
@@ -22,7 +22,7 @@
         "watch": "echo dev > test/mode.txt && tsc -p ./src/tsconfig.watch.json && npm run copy_runtime_deps_to_out && concurrently \"live-server ./ \" \"tsc -w -p ./src/tsconfig.watch.json \"",
         "test_release": "echo release > test/mode.txt && http-server -c-1 -p 8080 ./ -o index.html",
         "copy_types_to_release": "mcopy ./src/monaco.d.ts ./release/esm/monaco.d.ts && mcopy ./out/amd/monaco.contribution.d.ts ./release/esm/monaco.contribution.d.ts && mcopy ./src/monaco.d.ts ./release/min/monaco.d.ts && mcopy ./out/amd/monaco.contribution.d.ts ./release/min/monaco.contribution.d.ts && mcopy ./node_modules/@kusto/language-service/Kusto.JavaScript.Client.min.js  ./release/min/kusto.javascript.client.min.js && mcopy ./node_modules/@kusto/language-service-next/Kusto.Language.Bridge.min.js ./release/min/Kusto.Language.Bridge.min.js && mcopy ./node_modules/@kusto/language-service/bridge.min.js ./release/min/bridge.min.js && mcopy ./node_modules/@kusto/language-service/newtonsoft.json.min.js ./release/min/newtonsoft.json.min.js",
-        "prepublishOnly": "mkdirp release  && yarn run compile && node ./scripts/release.js && node ./scripts/bundle.js && yarn run copy_runtime_deps_to_out && yarn run copy_types_to_release",
+        "prepublishOnly": "mkdirp release  && npm run compile && node ./scripts/release.js && node ./scripts/bundle.js && npm run copy_runtime_deps_to_out && npm run copy_types_to_release",
         "test": "jest",
         "clean": "mrmdir ./out && mrmdir ./release"
     },

--- a/package/src/kustoWorker.ts
+++ b/package/src/kustoWorker.ts
@@ -2,7 +2,7 @@ import IWorkerContext = monaco.worker.IWorkerContext;
 
 import * as kustoService from './languageService/kustoLanguageService';
 import { LanguageSettings } from './languageService/settings';
-import { Schema, showSchema, ScalarParameter } from './languageService/schema';
+import { Schema, showSchema, ScalarParameter, Database } from './languageService/schema';
 import * as ls from 'vscode-languageserver-types';
 import { ColorizationRange } from './languageService/kustoLanguageService';
 import { RenderInfo } from './languageService/renderInfo';
@@ -27,6 +27,24 @@ export class KustoWorker {
 
     setSchema(schema: Schema) {
         return this._languageService.setSchema(schema);
+    }
+
+    addClusterToSchema(uri: string, clusterName: string, databasesNames: string[]): Promise<void> {
+        const document = this._getTextDocument(uri);
+        if (!document) {
+            console.error(`addClusterToSchema: document is ${document}. uri is ${uri}`);
+            return null;
+        }
+        return this._languageService.addClusterToSchema(document, clusterName, databasesNames);
+    }
+
+    addDatabaseToSchema(uri: string, clusterName: string, databaseSchema: Database): Promise<void> {
+        const document = this._getTextDocument(uri);
+        if (!document) {
+            console.error(`addDatabaseToSchema: document is ${document}. uri is ${uri}`);
+            return null;
+        }
+        return this._languageService.addDatabaseToSchema(document, clusterName, databaseSchema);
     }
 
     setSchemaFromShowSchema(schema: any, clusterConnectionString: string, databaseInContextName: string) {
@@ -246,6 +264,16 @@ export class KustoWorker {
 
     setParameters(parameters: ScalarParameter[]) {
         return this._languageService.setParameters(parameters);
+    }
+
+    getClusterReferences(uri: string, cursorOffset: number): Promise<kustoService.ClusterReference[]> {
+        let document = this._getTextDocument(uri);
+        return this._languageService.getClusterReferences(document, cursorOffset);
+    }
+
+    getDatabaseReferences(uri: string, cursorOffset: number): Promise<kustoService.DatabaseReference[]> {
+        let document = this._getTextDocument(uri);
+        return this._languageService.getDatabaseReferences(document, cursorOffset);
     }
 
     private _getTextDocument(uri: string): ls.TextDocument {

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -289,20 +289,20 @@ class KustoLanguageService implements LanguageService {
     debugGlobalState(globals: GlobalState) {
         // iterate over clusters
         console.log(`globals.Clusters.Count: ${globals.Clusters.Count}`);
-        for (var i2=0; i2 < globals.Clusters.Count; i2++) {
-            const cluster = globals.Clusters.getItem(i2);            
+        for (let i=0; i < globals.Clusters.Count; i++) {
+            const cluster = globals.Clusters.getItem(i);
             console.log(`cluster: ${cluster.Name}`);            
 
             // iterate over databases
             console.log(`cluster.Databases.Count: ${cluster.Databases.Count}`);
-            for (var i3=0; i3 < cluster.Databases.Count; i3++) {
-                const database = cluster.Databases.getItem(i3);
+            for (let i2=0; i2 < cluster.Databases.Count; i2++) {
+                const database = cluster.Databases.getItem(i2);
                 console.log(`cluster.database: [${cluster.Name}].[${database.Name}]`);
                 
                 // iterate over tables
                 console.log(`cluster.Databases.Tables.Count: ${database.Tables.Count}`);
-                for (var i4=0; i4 < database.Tables.Count; i4++) {
-                    const table = database.Tables.getItem(i4);
+                for (let i3=0; i3 < database.Tables.Count; i3++) {
+                    const table = database.Tables.getItem(i3);
                     console.log(`cluster.database.table: [${cluster.Name}].[${database.Name}].[${table.Name}]`);
                 }
             }
@@ -565,17 +565,17 @@ class KustoLanguageService implements LanguageService {
         if (!clusterReferences) {
             return Promise.resolve([]);
         }
-        var newClustersReferences: ClusterReference[] = [];
-        var newClustersReferencesSet = new Set(); // used to remove duplicates
-        var clustersInGlobalStateSet = new Set(); // used to remove clusters that are already in the global state 
+        let newClustersReferences: ClusterReference[] = [];
+        let newClustersReferencesSet = new Set(); // used to remove duplicates
+        let clustersInGlobalStateSet = new Set(); // used to remove clusters that are already in the global state 
 
         // create a set of cluster names from Global State
-        for (var i=0; i < this._kustoJsSchemaV2.Clusters.Count; i++) {
+        for (let i=0; i < this._kustoJsSchemaV2.Clusters.Count; i++) {
             clustersInGlobalStateSet.add(this._kustoJsSchemaV2.Clusters.getItem(i).Name.toLowerCase());
         }
 
         // Keep only unique clusters that aren't already exist in the Global State
-        for (var i=0; i < clusterReferences.Count; i++) {
+        for (let i=0; i < clusterReferences.Count; i++) {
             const clusterReference: k2.ClusterReference = clusterReferences.getItem(i);
             const clusterHostName = clusterReference.Cluster;
 
@@ -602,9 +602,9 @@ class KustoLanguageService implements LanguageService {
         if (!databasesReferences) {
             return Promise.resolve([]);
         }
-        var newDatabasesReferences: DatabaseReference[] = [];
-        var newDatabasesReferencesSet = new Set();
-        for (var i1=0; i1 < databasesReferences.Count; i1++) {
+        let newDatabasesReferences: DatabaseReference[] = [];
+        let newDatabasesReferencesSet = new Set();
+        for (let i1=0; i1 < databasesReferences.Count; i1++) {
             const databaseReference: k2.DatabaseReference = databasesReferences.getItem(i1);
 
             // ignore duplicates
@@ -615,14 +615,14 @@ class KustoLanguageService implements LanguageService {
             newDatabasesReferencesSet.add(databaseReferenceUniqueId);
 
             // ignore references that are already in the GlobalState.
-            var found = false;
-            for (var i2=0; i2 < this._kustoJsSchemaV2.Clusters.Count; i2++) {
+            let found = false;
+            for (let i2=0; i2 < this._kustoJsSchemaV2.Clusters.Count; i2++) {
                 const clusterFromGlobalState = this._kustoJsSchemaV2.Clusters.getItem(i2);
                 const clusterNameFromGlobalState = clusterFromGlobalState.Name;
                 const referencedClusterName = databaseReference.Cluster;
                 
                 if (referencedClusterName.toLowerCase() === clusterNameFromGlobalState.toLowerCase()) {
-                    for (var i3=0; i3 < clusterFromGlobalState.Databases.Count; i3++) {
+                    for (let i3=0; i3 < clusterFromGlobalState.Databases.Count; i3++) {
                         const databaseFromGlobalState = clusterFromGlobalState.Databases.getItem(i3);
                         const referencedDatabaseName = databaseReference.Database;
                         if (referencedDatabaseName.toLowerCase() === databaseFromGlobalState.Name.toLowerCase() && databaseFromGlobalState.Tables.Count > 0) {
@@ -812,7 +812,7 @@ class KustoLanguageService implements LanguageService {
 
     addClusterToSchema(document: TextDocument, clusterName: string, databaseNames: string[]): Promise<void> {
         return new Promise((resolve) => {
-            var clusterNameOnly = Kusto.Language.KustoFacts.GetHostName(clusterName);
+            let clusterNameOnly = Kusto.Language.KustoFacts.GetHostName(clusterName);
             let cluster: sym.ClusterSymbol = this._kustoJsSchemaV2.GetCluster$1(clusterNameOnly);
             if (cluster) {
                 // add databases that are not already in the cluster.
@@ -841,7 +841,7 @@ class KustoLanguageService implements LanguageService {
 
     addDatabaseToSchema(document: TextDocument, clusterName: string, databaseSchema: s.Database): Promise<void> {
         return new Promise((resolve) => {
-            var clusterHostName = Kusto.Language.KustoFacts.GetHostName(clusterName);
+            let clusterHostName = Kusto.Language.KustoFacts.GetHostName(clusterName);
             let cluster: sym.ClusterSymbol = this._kustoJsSchemaV2.GetCluster$1(clusterHostName);
             if (!cluster) {
                 cluster = new sym.ClusterSymbol.$ctor1(clusterHostName, null, false);
@@ -1092,7 +1092,7 @@ class KustoLanguageService implements LanguageService {
             // calculate command end position without \r\n.
             let commandEnd = command.End;
             const commandText = command.Text;
-            for (var i = commandText.length - 1; i >= 0; i--) {
+            for (let i = commandText.length - 1; i >= 0; i--) {
                 if (commandText[i] != '\r' && commandText[i] != '\n') {
                     break;
                 } else {
@@ -2039,14 +2039,14 @@ class KustoLanguageService implements LanguageService {
      * @param offsetFromEnd a negative number that will represent offset to the left. 0 means simple concat
      */
     private insertToString(originalString: string, stringToInsert: string, offsetFromEnd: number): string {
-        var index = originalString.length + offsetFromEnd;
+        let index = originalString.length + offsetFromEnd;
 
         if (offsetFromEnd >= 0 || index < 0) {
             return originalString; // Cannot insert before or after the string
         }
 
-        var before = originalString.substring(0, index);
-        var after = originalString.substring(index);
+        let before = originalString.substring(0, index);
+        let after = originalString.substring(index);
 
         return before + stringToInsert + after;
     }
@@ -2060,8 +2060,8 @@ class KustoLanguageService implements LanguageService {
         schema: k.KustoIntelliSenseQuerySchema | CmSchema | undefined,
         clusterType: s.ClusterType
     ) {
-        var queryParameters: any = new (List(String))();
-        var availableClusters: any = new (List(String))();
+        let queryParameters: any = new (List(String))();
+        let availableClusters: any = new (List(String))();
         this._parser = new k.CslCommandParser();
 
         if (clusterType == 'Engine') {

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -567,9 +567,16 @@ class KustoLanguageService implements LanguageService {
         }
         var newClustersReferences: ClusterReference[] = [];
         var newClustersReferencesSet = new Set(); // used to remove duplicates
+        var clustersInGlobalStateSet = new Set(); // used to remove clusters that are already in the global state 
 
-        for (var i1=0; i1 < clusterReferences.Count; i1++) {
-            const clusterReference: k2.ClusterReference = clusterReferences.getItem(i1);
+        // create a set of cluster names from Global State
+        for (var i=0; i < this._kustoJsSchemaV2.Clusters.Count; i++) {
+            clustersInGlobalStateSet.add(this._kustoJsSchemaV2.Clusters.getItem(i).Name.toLowerCase());
+        }
+
+        // Keep only unique clusters that aren't already exist in the Global State
+        for (var i=0; i < clusterReferences.Count; i++) {
+            const clusterReference: k2.ClusterReference = clusterReferences.getItem(i);
             const clusterHostName = clusterReference.Cluster;
 
             // ignore duplicates
@@ -578,18 +585,8 @@ class KustoLanguageService implements LanguageService {
             }
             newClustersReferencesSet.add(clusterHostName);
 
-            // ignore references that are already in the GlobalState.
-            var found = false;
-            for (var i2=0; i2 < this._kustoJsSchemaV2.Clusters.Count; i2++) {
-                const clusterFromGlobalState = this._kustoJsSchemaV2.Clusters.getItem(i2);
-                const clusterNameFromGlobalState = clusterFromGlobalState.Name;
-                if (clusterHostName.toLowerCase() === clusterNameFromGlobalState.toLowerCase()) {
-                    found=true;
-                    break;
-                }
-            }
-
-            if (!found) {
+            // ignore references that are already in the GlobalState.            
+            if (!clustersInGlobalStateSet.has(clusterHostName.toLowerCase())) {
                 newClustersReferences.push({ clusterName:  clusterHostName });
             }
         }

--- a/package/src/monaco.d.ts
+++ b/package/src/monaco.d.ts
@@ -119,6 +119,33 @@ declare module monaco.languages.kusto {
         doCurrentCommandFormat(uri: string, caretPosition: ls.Position): Promise<ls.TextEdit[]>;
         doValidation(uri: string, intervals: { start: number; end: number }[]): Promise<ls.Diagnostic[]>;
         setParameters(parameters: ScalarParameter[]): void;
+        /**
+         * Get all the database references from the current command. 
+         * If database's schema is already cached it will not be returned.
+         * This method should be used to get all the cross-databases in a command, then schema for the database should be fetched and added with addDatabaseToSchema.
+         * @example
+         * If the current command includes: cluster('help').database('Samples') 
+         * it returns [{ clusterName: 'help', databaseName 'Samples' }]
+         */
+        getDatabaseReferences(uri: string, cursorOffset: number): Promise<DatabaseReference[]>;
+        /**
+         * Get all the cluster references from the current command.
+         * If cluster's schema is already cached it will not be returned.
+         * This method should be used to get all the cross-clusters in a command, then schema for the cluster should be fetched and added with addClusterToSchema.
+         * @example
+         * If the current command includes: cluster('help')
+         * it returns [{ clusterName: 'help' }]
+         */
+        getClusterReferences(uri: string, cursorOffset: number): Promise<ClusterReference[]>;
+        /**
+         * Adds a database's scheme. Useful with getDatabaseReferences to load schema for cross-cluster commands.
+         */
+        addDatabaseToSchema(uri: string, clusterName: string, databaseSchema: Database): Promise<void>;
+        /**
+         * Adds a cluster's scheme (database names only). Useful with getClusterReferences to load schema for cross-cluster commands.
+         * To load a full database schema call addDatabaseToSchema.
+         */
+        addClusterToSchema(uri: string, clusterName: string, databasesNames: string[]): Promise<void>;
     }
 
     /**
@@ -232,6 +259,15 @@ declare module monaco.languages.kusto {
     export interface RenderInfo {
         options: RenderOptions;
         location: { startOffset: number; endOffset: number };
+    }
+
+    export interface DatabaseReference {
+        databaseName: string;
+        clusterName: string; 
+    };
+
+    export interface ClusterReference {
+        clusterName: string; 
     }
 
     export type RenderOptionKeys = keyof RenderOptions;

--- a/package/test/test.js
+++ b/package/test/test.js
@@ -488,6 +488,30 @@ fetch('./test/mode.txt')
                         monaco.languages.kusto.kustoDefaults.setLanguageSettings(monacoSettings);
                     });
                 };
+                window.getDatabaseReferences = () => {
+                    monaco.languages.kusto.getKustoWorker().then((workerAccessor) => {
+                        const model = editor.getModel();
+                        workerAccessor(model.uri).then((worker) => {
+                            worker
+                                .getDatabaseReferences(model.uri.toString(), model.getOffsetAt(editor.getPosition()))
+                                .then((renderInfo) => {
+                                    currentCommand.innerHTML = JSON.stringify(renderInfo);
+                                });
+                        });
+                    });
+                };
+                window.getClusterReferences = () => {
+                    monaco.languages.kusto.getKustoWorker().then((workerAccessor) => {
+                        const model = editor.getModel();
+                        workerAccessor(model.uri).then((worker) => {
+                            worker
+                                .getClusterReferences(model.uri.toString(), model.getOffsetAt(editor.getPosition()))
+                                .then((renderInfo) => {
+                                    currentCommand.innerHTML = JSON.stringify(renderInfo);
+                                });
+                        });
+                    });
+                }
                 window.setHelp();
             }
         );


### PR DESCRIPTION
### Summary

Add intellisense support for cross cluster queries. 

**Design:** 
This change supports The Get References Flow from KWE.
Every time the current query changes, :
1. check if there are any cluster references, if so load to Monaco-Kusto only the cluster name and the name of the databases. 
2. check if there are any database references, if so load to Monaco-Kusto the full database schema. 

Once the schema of the cluster and database is loaded in GlobalState they will not be returned again, until the schema is cleared.

**performance:**
GetDatabaseReferenfces and GetClusterReferenfces takes anywhere from 50ms for short queries (1-3 lines) to 2-10 seconds for bigger queries (~1500 lines). Since it is done in a worker thread it is acceptable. Most of the time is spent on re-parsing the query which needs to happen anyway. 

**Possible next step**
Trigger intellisense in those states: 
    a. `cluster('help').database(`
    b. `cluster('help').database('Samples').`

 ### Before
![before_1](https://user-images.githubusercontent.com/8294298/138348090-7cd2680b-e865-43bd-98aa-65ac154007e1.png)
![before_2](https://user-images.githubusercontent.com/8294298/138348099-4413cc3c-5620-441a-bbbb-daa8bff7c436.png)
![before_3](https://user-images.githubusercontent.com/8294298/138348109-4217f390-6753-4d35-8d11-1f85253f5e01.png)

 ### After
![after_1](https://user-images.githubusercontent.com/8294298/138348001-e86d4d6d-4311-47a5-a98b-8484f5b5a7af.png)
![after_2](https://user-images.githubusercontent.com/8294298/138348049-1c69d812-cafb-4b66-ab25-36fd7c7d4835.png)
![after_3](https://user-images.githubusercontent.com/8294298/138348062-14811a21-055e-4382-ae73-71ce33aa5b38.png)



