### PR TITLE
fix: low color contrast for foreground/background in suggestWidget

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ There are 2 APIs to set a Kusto schema:
 
 ## Changelog
 
+### 4.1.3
+
+- fix: low color contrast for foreground/background in suggestWidget
+
 ### 4.0.6
 
 - fix: `setSchemaFromShowSchema` now supports for external tables.

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/monaco.contribution.ts
+++ b/package/src/monaco.contribution.ts
@@ -129,7 +129,7 @@ export function setupMonacoKusto(monacoInstance: typeof monaco) {
         ],
         colors: {
             // see: https://code.visualstudio.com/api/references/theme-color#editor-widget-colors
-            'editorSuggestWidget.selectedBackground': '#2B88D8', // Fluent Theme Tertiary
+            'editorSuggestWidget.selectedBackground': '#93CFFB',
             'editorSuggestWidget.background': '#FAF9F8', // grey 10
         },
     });
@@ -157,8 +157,8 @@ export function setupMonacoKusto(monacoInstance: typeof monaco) {
         ],
         colors: {
             // see: https://code.visualstudio.com/api/references/theme-color#editor-widget-colors
-            'editorSuggestWidget.selectedBackground': '#106EBE', // Fluent Theme DarkAlt
-            'editorSuggestWidget.background': '#201F1E', // grey 190
+            'editorSuggestWidget.selectedBackground': '#001191', // Fluent High Contrast White Colors - Hyperlinks
+            'editorSuggestWidget.background': '#000000',
         },
     });
 

--- a/package/src/monaco.contribution.ts
+++ b/package/src/monaco.contribution.ts
@@ -62,11 +62,11 @@ const defaultLanguageSettings: monaco.languages.kusto.LanguageSettings = {
     enableHover: true,
     formatter: {
         indentationSize: 4,
-        pipeOperatorStyle: 'Smart'
+        pipeOperatorStyle: 'Smart',
     },
-    syntaxErrorAsMarkDown: {
-        enableSyntaxErrorAsMarkDown: false
-    }
+    syntaxErrorAsMarkDown: {
+        enableSyntaxErrorAsMarkDown: false,
+    },
 };
 
 function getKustoWorker(): Promise<any> {
@@ -95,17 +95,17 @@ export function setupMonacoKusto(monacoInstance: typeof monaco) {
     monacoInstance.languages.onLanguage('kusto', () => {
         withMode((mode) => mode.setupMode(kustoDefaults, monacoInstance));
     });
-    
+
     monacoInstance.languages.register({
         id: 'kusto',
         extensions: ['.csl', '.kql'],
     });
-    
+
     // TODO: asked if there's a cleaner way to register an editor contribution. looks like monaco has an internal contribution regstrar but it's no exposed in the API.
     // https://stackoverflow.com/questions/46700245/how-to-add-an-ieditorcontribution-to-monaco-editor
     let commandHighlighter: KustoCommandHighlighter;
     let commandFormatter: KustoCommandFormatter;
-    
+
     monacoInstance.editor.defineTheme('kusto-light', {
         base: 'vs',
         inherit: true,
@@ -127,9 +127,13 @@ export function setupMonacoKusto(monacoInstance: typeof monaco) {
             { token: 'annotation', foreground: '9400D3' }, // ClientDirectiveToken DarkViolet
             { token: 'invalid', background: 'cd3131' },
         ],
-        colors: {},
+        colors: {
+            // see: https://code.visualstudio.com/api/references/theme-color#editor-widget-colors
+            'editorSuggestWidget.focusHighlightForeground': 'C7E0F4', // Fluent Theme Light
+            'editorSuggestWidget.background': 'FAF9F8', // grey 10
+        },
     });
-    
+
     monacoInstance.editor.defineTheme('kusto-dark', {
         base: 'vs-dark',
         inherit: true,
@@ -151,28 +155,32 @@ export function setupMonacoKusto(monacoInstance: typeof monaco) {
             { token: 'annotation', foreground: 'b5cea8' }, // ClientDirectiveToken DarkViolet
             { token: 'invalid', background: 'cd3131' },
         ],
-        colors: {},
+        colors: {
+            // see: https://code.visualstudio.com/api/references/theme-color#editor-widget-colors
+            'editorSuggestWidget.focusHighlightForeground': '605E5C', // grey 130
+            'editorSuggestWidget.background': '323130', // grey 160
+        },
     });
-    
+
     monacoInstance.editor.defineTheme('kusto-dark2', {
         base: 'vs-dark',
         inherit: true,
         rules: [],
         colors: { 'editor.background': '#1B1A19' }, // gray 200
     });
-    
+
     // Initialize kusto specific language features that don't currently have a natural way to extend using existing apis.
     // Most other language features are initialized in kustoMode.ts
     monacoInstance.editor.onDidCreateEditor((editor) => {
         // hook up extension methods to editor.
         extend(editor);
-    
+
         commandHighlighter = new KustoCommandHighlighter(editor);
-    
+
         if (isStandaloneCodeEditor(editor)) {
             commandFormatter = new KustoCommandFormatter(editor);
         }
-    
+
         triggerSuggestDialogWhenCompletionItemSelected(editor);
     });
 
@@ -185,7 +193,8 @@ export function setupMonacoKusto(monacoInstance: typeof monaco) {
                 kustoDefaults.languageSettings.openSuggestionDialogAfterPreviousSuggestionAccepted
             ) {
                 var didAcceptSuggestion =
-                    event.source === 'modelChange' && event.reason === monaco.editor.CursorChangeReason.RecoverFromMarkers;
+                    event.source === 'modelChange' &&
+                    event.reason === monaco.editor.CursorChangeReason.RecoverFromMarkers;
                 if (!didAcceptSuggestion) {
                     return;
                 }
@@ -203,7 +212,6 @@ export function setupMonacoKusto(monacoInstance: typeof monaco) {
             }
         });
     }
-    
 }
 
 function isStandaloneCodeEditor(editor: monaco.editor.ICodeEditor): editor is monaco.editor.IStandaloneCodeEditor {

--- a/package/src/monaco.contribution.ts
+++ b/package/src/monaco.contribution.ts
@@ -129,8 +129,8 @@ export function setupMonacoKusto(monacoInstance: typeof monaco) {
         ],
         colors: {
             // see: https://code.visualstudio.com/api/references/theme-color#editor-widget-colors
-            'editorSuggestWidget.focusHighlightForeground': 'C7E0F4', // Fluent Theme Light
-            'editorSuggestWidget.background': 'FAF9F8', // grey 10
+            'editorSuggestWidget.selectedBackground': '#2B88D8', // Fluent Theme Tertiary
+            'editorSuggestWidget.background': '#FAF9F8', // grey 10
         },
     });
 
@@ -157,8 +157,8 @@ export function setupMonacoKusto(monacoInstance: typeof monaco) {
         ],
         colors: {
             // see: https://code.visualstudio.com/api/references/theme-color#editor-widget-colors
-            'editorSuggestWidget.focusHighlightForeground': '605E5C', // grey 130
-            'editorSuggestWidget.background': '323130', // grey 160
+            'editorSuggestWidget.selectedBackground': '#106EBE', // Fluent Theme DarkAlt
+            'editorSuggestWidget.background': '#201F1E', // grey 190
         },
     });
 


### PR DESCRIPTION
# A11y color contrast 

These changes address the color contrast between the focused item and background of the suggestion widget. 

## The issue

For light theme:

![MAS1 4 11 Luminosity ratio for the focus indicator on the items define on 'intellisense' pop-up window is less than 3 1 that is 1 1 1  (1)](https://user-images.githubusercontent.com/6274727/149032108-c7a98e97-8a9f-430c-91d7-5d9785f0e5b4.png)

For dark theme:

![image](https://user-images.githubusercontent.com/6274727/149032209-b1773271-2091-4677-9c1a-2e771daef33f.png)


## The fix

We need to adjust the background color for the suggest widget and the focused item. 


| Theme | Before | After |
| -- | -- | -- |
| Light | ![image](https://user-images.githubusercontent.com/6274727/155246463-96d4ee90-027d-437f-96a4-01f310e6c785.png) | ![image](https://user-images.githubusercontent.com/6274727/155246056-06714526-2018-4611-8475-d6de4a1f2c05.png) |
| Dark | ![image](https://user-images.githubusercontent.com/6274727/155246492-24dfccc3-b582-46dc-ad0a-6319897158d7.png)| ![image](https://user-images.githubusercontent.com/6274727/155246113-e095e354-1612-40c7-8fac-23ca7d3a656f.png) | 