### PR TITLE
fix: missing colors for kusto-dark2 theme

### DIFF
--- a/package/src/monaco.contribution.ts
+++ b/package/src/monaco.contribution.ts
@@ -166,7 +166,12 @@ export function setupMonacoKusto(monacoInstance: typeof monaco) {
         base: 'vs-dark',
         inherit: true,
         rules: [],
-        colors: { 'editor.background': '#1B1A19' }, // gray 200
+        colors: {
+            'editor.background': '#1B1A19', // gray 200
+            // see: https://code.visualstudio.com/api/references/theme-color#editor-widget-colors
+            'editorSuggestWidget.selectedBackground': '#001191', // Fluent High Contrast White Colors - Hyperlinks
+            'editorSuggestWidget.background': '#000000',
+        },
     });
 
     // Initialize kusto specific language features that don't currently have a natural way to extend using existing apis.


### PR DESCRIPTION
### Summary

My previous PR to include new colors for contrast forgot to also define them for the `kusto-dark2` theme. This PR adds them for `kusto-dark2`