### PR TITLE
fix: if enabled, trigger suggestion if previous suggestion is selecte…

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ There are 2 APIs to set a Kusto schema:
 
 ## Changelog
 
+### 4.1.8
+
+- fix: trigger suggestion when previous suggestion selected.
+
 ### 4.1.6
 
 - fix: low color contrast for foreground/background in suggestWidget for dark theme

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "4.1.7",
+    "version": "4.1.8",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/monaco.contribution.ts
+++ b/package/src/monaco.contribution.ts
@@ -197,22 +197,18 @@ export function setupMonacoKusto(monacoInstance: typeof monaco) {
                 kustoDefaults.languageSettings.openSuggestionDialogAfterPreviousSuggestionAccepted
             ) {
                 var didAcceptSuggestion =
-                    event.source === 'modelChange' &&
-                    event.reason === monaco.editor.CursorChangeReason.RecoverFromMarkers;
+                    event.source === 'snippet' && event.reason === monaco.editor.CursorChangeReason.NotSet;
                 if (!didAcceptSuggestion) {
                     return;
                 }
                 event.selection;
-                const completionText = editor.getModel().getValueInRange(event.selection);
-                if (completionText[completionText.length - 1] === ' ') {
-                    // OK so now we in a situation where we know a suggestion was selected and we want to trigger another one.
-                    // the only problem is that the suggestion widget itself listens to this same event in order to know it needs to close.
-                    // The only problem is that we're ahead in line, so we're triggering a suggest operation that will be shut down once
-                    // the next callback is called. This is why we're waiting here - to let all the callbacks run synchronously and be
-                    // the 'last' subscriber to run. Granted this is hacky, but until monaco provides a specific event for suggestions,
-                    // this is the best we have.
-                    setTimeout(() => editor.trigger('monaco-kusto', 'editor.action.triggerSuggest', {}), 10);
-                }
+                // OK so now we in a situation where we know a suggestion was selected and we want to trigger another one.
+                // the only problem is that the suggestion widget itself listens to this same event in order to know it needs to close.
+                // The only problem is that we're ahead in line, so we're triggering a suggest operation that will be shut down once
+                // the next callback is called. This is why we're waiting here - to let all the callbacks run synchronously and be
+                // the 'last' subscriber to run. Granted this is hacky, but until monaco provides a specific event for suggestions,
+                // this is the best we have.
+                setTimeout(() => editor.trigger('monaco-kusto', 'editor.action.triggerSuggest', {}), 10);
             }
         });
     }


### PR DESCRIPTION
…d now works

### Summary
Monaco version changes caused this to break. fixing.
We will now trigger another intellisense dialog when selecting an intellisense dialog.
 <!--

 Link to the issue describing the bug that you're fixing.

 Provide a general description of the code changes in your pull request.

 -->

 ### Other Information

 <!--

 If there's anything else that's important and relevant to your pull request, mention that information here.

 -->