### PR TITLE
fix: add enableWarnings and enableSuggestions to the worker api

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.1.1",
+    "version": "5.1.2",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/kustoWorker.ts
+++ b/package/src/kustoWorker.ts
@@ -190,9 +190,9 @@ export class KustoWorker {
         return completions;
     }
 
-    doValidation(uri: string, intervals: { start: number; end: number }[]): Promise<ls.Diagnostic[]> {
+    doValidation(uri: string, intervals: { start: number; end: number }[], includeWarnings?: boolean, includeSuggestions?: boolean): Promise<ls.Diagnostic[]> {
         const document = this._getTextDocument(uri);
-        const diagnostics = this._languageService.doValidation(document, intervals);
+        const diagnostics = this._languageService.doValidation(document, intervals, includeWarnings, includeSuggestions);
         return diagnostics;
     }
 

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -130,7 +130,7 @@ export interface LanguageService {
     doDocumentFormat(document: TextDocument): Promise<ls.TextEdit[]>;
     doCurrentCommandFormat(document: TextDocument, caretPosition: ls.Position): Promise<ls.TextEdit[]>;
     doFolding(document: TextDocument): Promise<FoldingRange[]>;
-    doValidation(document: TextDocument, intervals: { start: number; end: number }[]): Promise<ls.Diagnostic[]>;
+    doValidation(document: TextDocument, intervals: { start: number; end: number }[], includeWarnings?: boolean, includeSuggestions?: boolean): Promise<ls.Diagnostic[]>;
     doColorization(document: TextDocument, intervals: { start: number; end: number }[]): Promise<ColorizationRange[]>;
     doRename(document: TextDocument, position: ls.Position, newName: string): Promise<ls.WorkspaceEdit | undefined>;
     doHover(document: TextDocument, position: ls.Position): Promise<ls.Hover | undefined>;

--- a/package/src/monaco.d.ts
+++ b/package/src/monaco.d.ts
@@ -120,7 +120,7 @@ declare module monaco.languages.kusto {
         doDocumentFormat(uri: string): Promise<ls.TextEdit[]>;
         doRangeFormat(uri: string, range: ls.Range): Promise<ls.TextEdit[]>;
         doCurrentCommandFormat(uri: string, caretPosition: ls.Position): Promise<ls.TextEdit[]>;
-        doValidation(uri: string, intervals: { start: number; end: number }[]): Promise<ls.Diagnostic[]>;
+        doValidation(uri: string, intervals: { start: number; end: number }[], includeWarnings?: boolean, includeSuggestions?: boolean): Promise<ls.Diagnostic[]>;
         setParameters(parameters: ScalarParameter[]): void;
         /**
          * Get all the database references from the current command. 


### PR DESCRIPTION
### Summary

doValidation in kustoLanguageService and doValidation in  kustoWorker can use custom flags to enable warnings and suggestions