### PR TITLE
upgrade lang service to 0.0.55 and old language service to 0.0.36

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -736,14 +736,14 @@
       }
     },
     "@kusto/language-service": {
-      "version": "2.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@kusto/language-service/-/language-service-2.0.0-beta.0.tgz",
-      "integrity": "sha512-HBMASNCxtUe+BPOONpiXhzlCXuS0UIWl9YRrh521dTbEsoDwBN7Orlq6SUlDqKKdy7i4N4+7KtGFwwRjsgke7A=="
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@kusto/language-service/-/language-service-0.0.36.tgz",
+      "integrity": "sha512-5szm3K9OzeNY0kGTruR/hDagLJ4b7z4lod0NriFiJsf+SWPIRfIjcptVaucOa1VSaCbD41Ui5vOGoZ9h9lqk3Q=="
     },
     "@kusto/language-service-next": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/@kusto/language-service-next/-/language-service-next-0.0.54.tgz",
-      "integrity": "sha512-BloBx3ImzMK5bowp276pmqqiUuTA8Cn+vlDHJk70PYHxi7GUoIbgJ+w7ewbIqCcztXLwCpUtm3TXQwYAlrTh6A=="
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/@kusto/language-service-next/-/language-service-next-0.0.55.tgz",
+      "integrity": "sha512-50z0UYjwpyzT720FL2jGmyRmxMhEtYchLGUEpRbEiCALkiJAaQ4tT8gwpUsO4uqV7/AE31qegLONTAAEAT1cPw=="
     },
     "@sinonjs/commons": {
       "version": "1.8.0",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.1.2",
+    "version": "5.1.3",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"
@@ -54,8 +54,8 @@
         "xregexp": "^3.2.0"
     },
     "dependencies": {
-        "@kusto/language-service": "2.0.0-beta.0",
-        "@kusto/language-service-next": "0.0.54"
+        "@kusto/language-service": "0.0.36",
+        "@kusto/language-service-next": "0.0.55"
     },
     "peerDependencies": {
         "monaco-editor": "0.33.0"


### PR DESCRIPTION
### Summary
Upgrade @kusto/language-service-next to version 0.0.55 and @kusto/language-service to version 0.0.36
 <!--

 Link to the issue describing the bug that you're fixing.

 Provide a general description of the code changes in your pull request.

 -->

 ### Other Information

 <!--

 If there's anything else that's important and relevant to your pull request, mention that information here.

 -->