### PR TITLE
fix: Materialized view tables not recognized

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kusto/monaco-kusto",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.1.4",
+    "version": "5.1.5",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -1826,13 +1826,14 @@ class KustoLanguageService implements LanguageService {
             );
         };
 
-        const createTableSymbol: (tbl: s.Table) => sym.TableSymbol = (tbl) => {
+        const createTableSymbol: (tbl: s.Table) => sym.TableSymbol | sym.MaterializedViewSymbol = (tbl) => {
             const columnSymbols = tbl.columns.map((col) => KustoLanguageService.createColumnSymbol(col));
             let symbol = new sym.TableSymbol.$ctor3(tbl.name, columnSymbols);
             symbol.Description = tbl.docstring;
 
             switch (tbl.entityType) {
                 case 'MaterializedViewTable':
+                    symbol = new sym.MaterializedViewSymbol(tbl.name, symbol.Columns, null, tbl.docstring)
                     symbol = symbol.WithIsMaterializedView(true);
                     break;
                 case 'ExternalTable':


### PR DESCRIPTION
Materialized view tables are not recognized in schema.
Creating Materialized view symbol will fix this recognition issue.
Next phase will be to support providing mvQuery property to the symbol, to allow the analyzers functionality.