### PR TITLE
fix: Invalidate strings if there's a line break

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.1.8",
+    "version": "5.1.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@kusto/monaco-kusto",
-            "version": "5.1.8",
+            "version": "5.1.9",
             "license": "MIT",
             "dependencies": {
                 "@kusto/language-service": "0.0.36",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.1.8",
+    "version": "5.1.9",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/languageService/kustoMonarchLanguageDefinition.ts
+++ b/package/src/languageService/kustoMonarchLanguageDefinition.ts
@@ -48,7 +48,7 @@ export const KustoLanguageDefinition: any = {
             [/((\d+(\.\d*)?)|(\.\d+))([eE][\-+]?\d+)?/, 'number']
         ],
         strings: [
-            [/'([^'\\]|\\.)*$/, 'string.invalid'],
+            [/'([^'])*$/, 'string.invalid'],
             [/H'/, { token: 'string.quote', bracket: '@open', next: '@string' }],
             [/h'/, { token: 'string.quote', bracket: '@open', next: '@string' }],
             [/'/, { token: 'string.quote', bracket: '@open', next: '@string' }]
@@ -59,7 +59,7 @@ export const KustoLanguageDefinition: any = {
             [/'/, { token: 'string.quote', bracket: '@close', next: '@pop' }]
         ],
         dqstrings: [
-            [/"([^"\\]|\\.)*$/, 'string.invalid'],
+            [/"([^"])*$/, 'string.invalid'],
             [/H"/, { token: 'string.quote', bracket: '@open', next: '@dqstring' }],
             [/h"/, { token: 'string.quote', bracket: '@open', next: '@dqstring' }],
             [/"/, { token: 'string.quote', bracket: '@open', next: '@dqstring' }]

--- a/package/src/languageService/kustoMonarchLanguageDefinition.ts
+++ b/package/src/languageService/kustoMonarchLanguageDefinition.ts
@@ -48,6 +48,7 @@ export const KustoLanguageDefinition: any = {
             [/((\d+(\.\d*)?)|(\.\d+))([eE][\-+]?\d+)?/, 'number']
         ],
         strings: [
+            [/'([^'\\]|\\.)*$/, 'string.invalid'],
             [/H'/, { token: 'string.quote', bracket: '@open', next: '@string' }],
             [/h'/, { token: 'string.quote', bracket: '@open', next: '@string' }],
             [/'/, { token: 'string.quote', bracket: '@open', next: '@string' }]
@@ -58,6 +59,7 @@ export const KustoLanguageDefinition: any = {
             [/'/, { token: 'string.quote', bracket: '@close', next: '@pop' }]
         ],
         dqstrings: [
+            [/"([^"\\]|\\.)*$/, 'string.invalid'],
             [/H"/, { token: 'string.quote', bracket: '@open', next: '@dqstring' }],
             [/h"/, { token: 'string.quote', bracket: '@open', next: '@dqstring' }],
             [/"/, { token: 'string.quote', bracket: '@open', next: '@dqstring' }]

--- a/package/src/languageService/kustoMonarchLanguageDefinition.ts
+++ b/package/src/languageService/kustoMonarchLanguageDefinition.ts
@@ -55,7 +55,6 @@ export const KustoLanguageDefinition: any = {
         ],
         string: [
             [/[^']+/, 'string'],
-            [/''/, 'string'],
             [/'/, { token: 'string.quote', bracket: '@close', next: '@pop' }]
         ],
         dqstrings: [
@@ -66,7 +65,6 @@ export const KustoLanguageDefinition: any = {
         ],
         dqstring: [
             [/[^"]+/, 'string'],
-            [/""/, 'string'],
             [/"/, { token: 'string.quote', bracket: '@close', next: '@pop' }]
         ],
 


### PR DESCRIPTION
Issue is for the following example:

StormEvents | project StartTime , State | where State contains "Texas" | count"

StormEvents
| take 6

Since there's a double quote in the end of the first query, it would treat the second query as a string, even though it should be  completely new query.

Added an invalidate rule to make sure that the string literal is invalidated if there's a new line.