### PR TITLE
fix: Eager mode not to auto-complete if we didn't reach an ending token

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.2.0",
+    "version": "5.2.1",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/monaco.contribution.ts
+++ b/package/src/monaco.contribution.ts
@@ -195,7 +195,9 @@ export function setupMonacoKusto(monacoInstance: typeof monaco) {
             ) {
                 var didAcceptSuggestion =
                     event.source === 'snippet' && event.reason === monaco.editor.CursorChangeReason.NotSet;
-                if (!didAcceptSuggestion) {
+                // If the word at the current position is not null - meaning we did not add a space after completion.
+                // In this case we don't want to activate the eager mode, since it will display the current selected word..
+                if (!didAcceptSuggestion || editor.getModel().getWordAtPosition(event.selection.getPosition()) !== null) {
                     return;
                 }
                 event.selection;


### PR DESCRIPTION
Sometimes when auto completing, we stay on the same word.
This causes an issue that it suggests the same word that was already chosen in the previous auto complete.