### PR TITLE
Completion items to be case insensitive

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.3.0",
+    "version": "5.3.1",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -415,12 +415,12 @@ class KustoLanguageService implements LanguageService {
                               format: ls.InsertTextFormat.PlainText,
                           };
                 const lsItem = ls.CompletionItem.create(kItem.DisplayText);
-
                 const startPosition = document.positionAt(completionItems.EditStart);
                 const endPosition = document.positionAt(completionItems.EditStart + completionItems.EditLength);
                 lsItem.textEdit = ls.TextEdit.replace(ls.Range.create(startPosition, endPosition), textToInsert);
                 lsItem.sortText = this.getSortText(i + 1);
-                // lsItem.filterText = lsItem.sortText;
+                // filterText is the label as lower case to prevent case sensitive completions
+                lsItem.filterText = lsItem.label?.toLowerCase();
                 lsItem.kind = this.kustoKindToLsKindV2(kItem.Kind);
                 lsItem.insertTextFormat = format;
                 lsItem.detail = helpTopic ? helpTopic.ShortDescription : undefined;


### PR DESCRIPTION
Completion items to be case insensitive.

Before this PR:
![image](https://user-images.githubusercontent.com/110340694/201514791-cf7828fd-0280-417e-b63a-761c17d0373e.png)


After this PR:
![image](https://user-images.githubusercontent.com/110340694/201514767-f575f50c-e2c7-43b8-bf3a-719a3e321aa6.png)
