### PR TITLE
fix completion items missing description

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.3.0",
+    "version": "5.3.1",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -427,13 +427,6 @@ class KustoLanguageService implements LanguageService {
                 lsItem.documentation = helpTopic
                     ? { value: helpTopic.LongDescription, kind: ls.MarkupKind.Markdown }
                     : undefined;
-                    if (lsItem.label.includes("format_byt")) {
-                        console.log('HERE', kItem)
-                        console.log('v1CompletionOption', v1CompletionOption)
-                        console.log('helpTopic', helpTopic)
-                        console.log('completiong', k.CslDocumentation.Instance.GetTopic(v1CompletionOption))
-
-                    }
                 return lsItem;
             });
 

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -229,23 +229,23 @@ class KustoLanguageService implements LanguageService {
     private _newlineAppendPipePolicy: Kusto.Data.IntelliSense.ApplyPolicy;
     private _toOptionKind: { [completionKind in k2.CompletionKind]: k.OptionKind } = {
         [k2.CompletionKind.AggregateFunction]: k.OptionKind.FunctionAggregation,
-        [k2.CompletionKind.BuiltInFunction]: k.OptionKind.FunctionServerSide,
+        [k2.CompletionKind.BuiltInFunction]: k.OptionKind.FunctionScalar,
         [k2.CompletionKind.Cluster]: k.OptionKind.Database,
         [k2.CompletionKind.Column]: k.OptionKind.Column,
-        [k2.CompletionKind.CommandPrefix]: k.OptionKind.None,
+        [k2.CompletionKind.CommandPrefix]: k.OptionKind.Command,
         [k2.CompletionKind.Database]: k.OptionKind.Database,
         [k2.CompletionKind.DatabaseFunction]: k.OptionKind.FunctionServerSide,
-        [k2.CompletionKind.Example]: k.OptionKind.None,
+        [k2.CompletionKind.Example]: k.OptionKind.Literal,
         [k2.CompletionKind.Identifier]: k.OptionKind.None,
-        [k2.CompletionKind.Keyword]: k.OptionKind.None,
+        [k2.CompletionKind.Keyword]: k.OptionKind.Option,
         [k2.CompletionKind.LocalFunction]: k.OptionKind.FunctionLocal,
         [k2.CompletionKind.MaterialiedView]: k.OptionKind.MaterializedView,
         [k2.CompletionKind.Parameter]: k.OptionKind.Parameter,
         [k2.CompletionKind.Punctuation]: k.OptionKind.None,
         [k2.CompletionKind.QueryPrefix]: k.OptionKind.Operator,
-        [k2.CompletionKind.RenderChart]: k.OptionKind.Operator,
+        [k2.CompletionKind.RenderChart]: k.OptionKind.OptionRender,
         [k2.CompletionKind.ScalarInfix]: k.OptionKind.None,
-        [k2.CompletionKind.ScalarPrefix]: k.OptionKind.None,
+        [k2.CompletionKind.ScalarPrefix]: k.OptionKind.Literal,
         [k2.CompletionKind.ScalarType]: k.OptionKind.DataType,
         [k2.CompletionKind.Syntax]: k.OptionKind.None,
         [k2.CompletionKind.Table]: k.OptionKind.Table,
@@ -427,6 +427,13 @@ class KustoLanguageService implements LanguageService {
                 lsItem.documentation = helpTopic
                     ? { value: helpTopic.LongDescription, kind: ls.MarkupKind.Markdown }
                     : undefined;
+                    if (lsItem.label.includes("format_byt")) {
+                        console.log('HERE', kItem)
+                        console.log('v1CompletionOption', v1CompletionOption)
+                        console.log('helpTopic', helpTopic)
+                        console.log('completiong', k.CslDocumentation.Instance.GetTopic(v1CompletionOption))
+
+                    }
                 return lsItem;
             });
 

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -227,6 +227,10 @@ class KustoLanguageService implements LanguageService {
         | k.DataManagerIntelliSenseRulesProvider
         | k.ClusterManagerIntelliSenseRulesProvider;
     private _newlineAppendPipePolicy: Kusto.Data.IntelliSense.ApplyPolicy;
+    /**
+     * Taken from:
+     * https://msazure.visualstudio.com/One/_git/Azure-Kusto-Service?path=/Src/Tools/Kusto.Explorer.Control/QueryEditors/KustoScriptEditor/KustoScriptEditorControl2.xaml.cs&version=GBdev&line=2075&lineEnd=2075&lineStartColumn=9&lineEndColumn=77&lineStyle=plain&_a=contents
+    */
     private _toOptionKind: { [completionKind in k2.CompletionKind]: k.OptionKind } = {
         [k2.CompletionKind.AggregateFunction]: k.OptionKind.FunctionAggregation,
         [k2.CompletionKind.BuiltInFunction]: k.OptionKind.FunctionScalar,


### PR DESCRIPTION
Some functions in the completion list missed descriptions and documentations.
Issue was a mismatch between the code in Kusto Service and in monaco-kusto.

For example:
![image](https://user-images.githubusercontent.com/110340694/201625609-f55d07fa-50de-4e66-bd7a-4841d5e5f2d0.png)


After the fix it looks alright:
![image](https://user-images.githubusercontent.com/110340694/201625669-f6d232f2-2980-448e-a4fd-4667bd1fcbfb.png)
