### PR TITLE
fix: Suggestion list doc links not working

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.3.3",
+    "version": "5.3.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@kusto/monaco-kusto",
-            "version": "5.3.3",
+            "version": "5.3.5",
             "license": "MIT",
             "dependencies": {
                 "@kusto/language-service": "0.0.38",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.3.4",
+    "version": "5.3.5",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/languageFeatures.ts
+++ b/package/src/languageFeatures.ts
@@ -14,7 +14,6 @@ import ClassificationKind = Kusto.Language.Editor.ClassificationKind;
 import { Schema } from './languageService/schema';
 import { FoldingRange } from 'vscode-languageserver-types';
 import { ClassifiedRange } from './languageService/kustoLanguageService';
-import { UriComponents } from 'monaco-editor';
 
 export interface WorkerAccessor {
     (first: Uri, ...more: Uri[]): Promise<KustoWorker>;

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -360,6 +360,10 @@ class KustoLanguageService implements LanguageService {
         }
     }
 
+    private formatHelpTopic(helpTopic: k.CslTopicDocumentation) {
+        return `**${helpTopic.Name} [(view online)](${helpTopic.Url})**\n\n${helpTopic.LongDescription}`;
+    }
+
     doCompleteV2(document: TextDocument, position: ls.Position): Promise<ls.CompletionList> {
         if (!document) {
             return Promise.resolve(ls.CompletionList.create([]));
@@ -429,7 +433,7 @@ class KustoLanguageService implements LanguageService {
                 lsItem.insertTextFormat = format;
                 lsItem.detail = helpTopic ? helpTopic.ShortDescription : undefined;
                 lsItem.documentation = helpTopic
-                    ? { value: helpTopic.LongDescription, kind: ls.MarkupKind.Markdown }
+                    ? { value: this.formatHelpTopic(helpTopic), kind: ls.MarkupKind.Markdown }
                     : undefined;
                 return lsItem;
             });

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -360,6 +360,9 @@ class KustoLanguageService implements LanguageService {
         }
     }
 
+    /**
+     * Prepending the doc of the actual topic at the top
+     */
     private formatHelpTopic(helpTopic: k.CslTopicDocumentation) {
         return `**${helpTopic.Name} [(view online)](${helpTopic.Url})**\n\n${helpTopic.LongDescription}`;
     }

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -392,8 +392,8 @@ class KustoLanguageService implements LanguageService {
                 disabledItems[item] = k2.CompletionKind.Unknown;
             });
         }
-
-        let items: ls.CompletionItem[] = this.toArray<k2.CompletionItem>(completionItems.Items)
+        const itemsAsArray = this.toArray<k2.CompletionItem>(completionItems.Items);
+        let items: ls.CompletionItem[] = itemsAsArray
             .filter(
                 (item) =>
                     !(
@@ -427,11 +427,14 @@ class KustoLanguageService implements LanguageService {
                           };
                 const lsItem = ls.CompletionItem.create(kItem.DisplayText);
 
+                // Adding to columns a prefix to their sortText so they will appear first in the list
+                const sortTextPrefix = lsItem.kind === ls.CompletionItemKind.Field ? 0 : itemsAsArray.length; 
                 const startPosition = document.positionAt(completionItems.EditStart);
                 const endPosition = document.positionAt(completionItems.EditStart + completionItems.EditLength);
                 lsItem.textEdit = ls.TextEdit.replace(ls.Range.create(startPosition, endPosition), textToInsert);
-                lsItem.sortText = this.getSortText(i + 1);
-                // lsItem.filterText = lsItem.sortText;
+                lsItem.sortText = this.getSortText(sortTextPrefix + i + 1);
+                // Changing the first letter to be lower case, to ignore case-sensitive matching
+                lsItem.filterText = lsItem.label.charAt(0).toLowerCase() + lsItem.label.slice(1);
                 lsItem.kind = this.kustoKindToLsKindV2(kItem.Kind);
                 lsItem.insertTextFormat = format;
                 lsItem.detail = helpTopic ? helpTopic.ShortDescription : undefined;


### PR DESCRIPTION
- Better suggestion list matching - First show columns, then functions.
- Removing ".md" postfix from each link, and prepending the base URL for the docs when needed.
- Also adding the main doc link for the actual item:
![image](https://user-images.githubusercontent.com/110340694/204251607-1ee890e9-0152-4e9e-9a1b-6afd29d767ba.png)
