### PR TITLE
feat: Validate diagnostics on query on cursor change

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.3.5",
+    "version": "5.3.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@kusto/monaco-kusto",
-            "version": "5.3.5",
+            "version": "5.3.6",
             "license": "MIT",
             "dependencies": {
                 "@kusto/language-service": "0.0.38",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.3.5",
+    "version": "5.3.6",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/languageFeatures.ts
+++ b/package/src/languageFeatures.ts
@@ -26,7 +26,7 @@ export class DiagnosticsAdapter {
     private _contentListener: { [uri: string]: IDisposable } = Object.create(null);
     private _configurationListener: { [uri: string]: IDisposable } = Object.create(null);
     private _schemaListener: { [uri: string]: IDisposable } = Object.create(null);
-    private _cursorListener: { [uri: string]: IDisposable } = Object.create(null);
+    private _cursorListener: { [editorId: string]: IDisposable } = Object.create(null);
 
     constructor(
         private _monacoInstance: typeof monaco,


### PR DESCRIPTION
Add cursor listener on the editor, and run diagnostics on change.
Up until now diagnostics ran only on content change.