### PR TITLE
fix: Disable doc popup for completion items without documentation

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.3.6",
+    "version": "5.3.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@kusto/monaco-kusto",
-            "version": "5.3.6",
+            "version": "5.3.7",
             "license": "MIT",
             "dependencies": {
                 "@kusto/language-service": "0.0.38",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.3.6",
+    "version": "5.3.7",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/languageFeatures.ts
+++ b/package/src/languageFeatures.ts
@@ -706,6 +706,10 @@ function toTextEdit(textEdit: ls.TextEdit): monaco.editor.ISingleEditOperation {
 const DOCS_BASE_URL = "https://learn.microsoft.com/azure/data-explorer/kusto/query";
 
 function formatDocLink(docString?: string): monaco.languages.CompletionItem['documentation'] {
+    // If the docString is empty, we want to return undefined to prevent an empty documentation popup.
+    if (!docString) {
+        return undefined;
+    }
     const target: {[href: string]: monaco.UriComponents} = {}
     const urisProxy = new Proxy(target, {
         get(_target, prop, _receiver) {


### PR DESCRIPTION
Completion items that have empty documentation had an empty documentation popup.
Example for "between" operator:
![image](https://user-images.githubusercontent.com/110340694/208623317-e17b8e1e-b7d7-4a42-9346-a58ee7aea3fd.png)
