### PR TITLE
fix: Command palette completion list not showing when the editor has small height

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.3.7",
+    "version": "5.3.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@kusto/monaco-kusto",
-            "version": "5.3.7",
+            "version": "5.3.8",
             "license": "MIT",
             "dependencies": {
                 "@kusto/language-service": "0.0.38",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.3.7",
+    "version": "5.3.8",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/accessibilityUtils.ts
+++ b/package/src/accessibilityUtils.ts
@@ -5,6 +5,10 @@ export function runAccessibilityFixers() {
     fixCommandPalleteHeight();
 }
 
+/**
+ * Fixing command pallete completion list not showing with small height.
+ * Fix is from here: https://github.com/microsoft/monaco-editor/issues/70
+ */
 function fixCommandPalleteHeight() {
     let module = require("vs/base/parts/quickinput/browser/quickInputList");
     module.QuickInputList.prototype.layout = function (maxHeight: number) {

--- a/package/src/accessibilityUtils.ts
+++ b/package/src/accessibilityUtils.ts
@@ -1,0 +1,14 @@
+/**
+ * Run fixes for accessibility issues
+ */
+export function runAccessibilityFixers() {
+    fixCommandPalleteHeight();
+}
+
+function fixCommandPalleteHeight() {
+    let module = require("vs/base/parts/quickinput/browser/quickInputList");
+    module.QuickInputList.prototype.layout = function (maxHeight: number) {
+        this.list.getHTMLElement().style.maxHeight = maxHeight < 200 ? "200px" : Math.floor(maxHeight) + "px";
+        this.list.layout();
+    }
+}

--- a/package/src/accessibilityUtils.ts
+++ b/package/src/accessibilityUtils.ts
@@ -6,7 +6,7 @@ export function runAccessibilityFixers() {
 }
 
 /**
- * Fixing command pallete completion list not showing with small height.
+ * Fixing command palette completion list not showing with small height.
  * Fix is from here: https://github.com/microsoft/monaco-editor/issues/70
  */
 function fixCommandPalleteHeight() {

--- a/package/src/monaco.contribution.ts
+++ b/package/src/monaco.contribution.ts
@@ -6,6 +6,7 @@ import * as mode from './kustoMode';
 import KustoCommandHighlighter from './commandHighlighter';
 import KustoCommandFormatter from './commandFormatter';
 import { extend } from './extendedEditor';
+import { runAccessibilityFixers } from './accessibilityUtils';
 
 declare var require: <T>(moduleId: [string], callback: (module: T) => void) => void;
 
@@ -184,6 +185,8 @@ export function setupMonacoKusto(monacoInstance: typeof monaco) {
 
         triggerSuggestDialogWhenCompletionItemSelected(editor);
     });
+
+    runAccessibilityFixers();
 
     function triggerSuggestDialogWhenCompletionItemSelected(editor: monaco.editor.ICodeEditor) {
         editor.onDidChangeCursorSelection((event: monaco.editor.ICursorSelectionChangedEvent) => {


### PR DESCRIPTION
When the editor has small height, the completion list is not showing.
Fix is taken from here:
https://github.com/microsoft/monaco-editor/issues/70

Command palette completion not showing:
![image](https://user-images.githubusercontent.com/110340694/210313205-959af877-7e1a-4095-8843-5a34bc6e8915.png)
