### PR TITLE
fix: Setting "_kustoJsSchemaV2" to null causes crush in the setter

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "5.3.11",
+    "version": "5.3.12",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -927,6 +927,7 @@ class KustoLanguageService implements LanguageService {
 
     setSchema(schema: s.Schema): Promise<void> {
         this._schema = schema;
+        // We support intellisenseV2 only if the clusterType is "Engine", even if the setting is enabled
         if (this._languageSettings.useIntellisenseV2 && schema && schema.clusterType === 'Engine') {
             let kustoJsSchemaV2: GlobalState = this.convertToKustoJsSchemaV2(schema);
 

--- a/package/src/languageService/kustoLanguageService.ts
+++ b/package/src/languageService/kustoLanguageService.ts
@@ -47,7 +47,7 @@ class ParseProperties {
         private uri: string,
         private rulesProvider?: k.IntelliSenseRulesProviderBase,
         private parseMode?: k.ParseMode
-    ) {}
+    ) { }
 
     isParseNeeded(document: TextDocument, rulesProvider?: k.IntelliSenseRulesProviderBase, parseMode?: k.ParseMode) {
         if (
@@ -417,15 +417,15 @@ class KustoLanguageService implements LanguageService {
                 const { textToInsert, format } =
                     kItem.AfterText && kItem.AfterText.length > 0
                         ? {
-                              // Need to escape dollar sign since it is used as a placeholder in snippet.
-                              // Usually dollar sign is not a valid character in a function name, but grafana uses macros that start with dollars.
-                              textToInsert: `${kItem.EditText.replace('$', '\\$')}$0${kItem.AfterText}`,
-                              format: ls.InsertTextFormat.Snippet,
-                          }
+                            // Need to escape dollar sign since it is used as a placeholder in snippet.
+                            // Usually dollar sign is not a valid character in a function name, but grafana uses macros that start with dollars.
+                            textToInsert: `${kItem.EditText.replace('$', '\\$')}$0${kItem.AfterText}`,
+                            format: ls.InsertTextFormat.Snippet,
+                        }
                         : {
-                              textToInsert: kItem.EditText,
-                              format: ls.InsertTextFormat.PlainText,
-                          };
+                            textToInsert: kItem.EditText,
+                            format: ls.InsertTextFormat.PlainText,
+                        };
                 const lsItem = ls.CompletionItem.create(kItem.DisplayText);
 
                 // Adding to columns a prefix to their sortText so they will appear first in the list
@@ -784,14 +784,14 @@ class KustoLanguageService implements LanguageService {
                     // a command is affected if it intersects at least on of changed ranges.
                     command // command can be null. we're filtering all nulls in the array.
                         ? changeIntervals.some(
-                              ({ start: changeStart, end: changeEnd }) =>
-                                  // both intervals intersect if either the start or the end of interval A is inside interval B.
-                                  // If we deleted something at the end of a command, the interval will not intersect the current command.
-                                  // so we also want consider affected commands commands the end where the interval begins.
-                                  // hence the + 1.
-                                  (command.AbsoluteStart >= changeStart && command.AbsoluteStart <= changeEnd) ||
-                                  (changeStart >= command.AbsoluteStart && changeStart <= command.AbsoluteEnd + 1)
-                          )
+                            ({ start: changeStart, end: changeEnd }) =>
+                                // both intervals intersect if either the start or the end of interval A is inside interval B.
+                                // If we deleted something at the end of a command, the interval will not intersect the current command.
+                                // so we also want consider affected commands commands the end where the interval begins.
+                                // hence the + 1.
+                                (command.AbsoluteStart >= changeStart && command.AbsoluteStart <= changeEnd) ||
+                                (changeStart >= command.AbsoluteStart && changeStart <= command.AbsoluteEnd + 1)
+                        )
                         : false
                 );
 
@@ -876,11 +876,11 @@ class KustoLanguageService implements LanguageService {
             // a command is affected if it intersects at least on of changed ranges.
             block // command can be null. we're filtering all nulls in the array.
                 ? changeIntervals.some(
-                      ({ start: changeStart, end: changeEnd }) =>
-                          // both intervals intersect if either the start or the end of interval A is inside interval B.
-                          (block.Start >= changeStart && block.Start <= changeEnd) ||
-                          (changeStart >= block.Start && changeStart <= block.End + 1)
-                  )
+                    ({ start: changeStart, end: changeEnd }) =>
+                        // both intervals intersect if either the start or the end of interval A is inside interval B.
+                        (block.Start >= changeStart && block.Start <= changeEnd) ||
+                        (changeStart >= block.Start && changeStart <= block.End + 1)
+                )
                 : false
         );
     }
@@ -927,9 +927,8 @@ class KustoLanguageService implements LanguageService {
 
     setSchema(schema: s.Schema): Promise<void> {
         this._schema = schema;
-        if (this._languageSettings.useIntellisenseV2) {
-            let kustoJsSchemaV2: GlobalState =
-                schema && schema.clusterType === 'Engine' ? this.convertToKustoJsSchemaV2(schema) : null;
+        if (this._languageSettings.useIntellisenseV2 && schema && schema.clusterType === 'Engine') {
+            let kustoJsSchemaV2: GlobalState = this.convertToKustoJsSchemaV2(schema);
 
             this._kustoJsSchemaV2 = kustoJsSchemaV2;
             this._script = undefined;
@@ -1045,10 +1044,10 @@ class KustoLanguageService implements LanguageService {
                                 cslDefaultValue: inputParam.CslDefaultValue,
                                 columns: inputParam.Columns
                                     ? inputParam.Columns.map((col) => ({
-                                          name: col.Name,
-                                          type: col.Type,
-                                          cslType: col.CslType,
-                                      }))
+                                        name: col.Name,
+                                        type: col.Type,
+                                        cslType: col.CslType,
+                                    }))
                                     : (inputParam.Columns as undefined | null | []),
                             })),
                         })),
@@ -1659,7 +1658,7 @@ class KustoLanguageService implements LanguageService {
     }
     //#endregion
 
-    private static convertToEntityDataType(kustoType: string) {}
+    private static convertToEntityDataType(kustoType: string) { }
     /**
      * We do not want to expose Bridge.Net generated schema, so we expose a cleaner javascript schema.
      * Here it gets converted to the bridge.Net schema
@@ -2190,23 +2189,23 @@ class KustoLanguageService implements LanguageService {
             this._rulesProvider =
                 this._languageSettings && this._languageSettings.includeControlCommands
                     ? new k.CslIntelliSenseRulesProvider.$ctor1(
-                          engineSchema.Cluster,
-                          engineSchema,
-                          queryParameters,
-                          availableClusters,
-                          null,
-                          true,
-                          true
-                      )
+                        engineSchema.Cluster,
+                        engineSchema,
+                        queryParameters,
+                        availableClusters,
+                        null,
+                        true,
+                        true
+                    )
                     : new k.CslQueryIntelliSenseRulesProvider.$ctor1(
-                          engineSchema.Cluster,
-                          engineSchema,
-                          queryParameters,
-                          availableClusters,
-                          null,
-                          null,
-                          null
-                      );
+                        engineSchema.Cluster,
+                        engineSchema,
+                        queryParameters,
+                        availableClusters,
+                        null,
+                        null,
+                        null
+                    );
             return;
         }
 


### PR DESCRIPTION
This happens when using a cluster type that is not "Engine".
Fixing the issue by not setting _kustoJsSchemaV2 at all when the cluster type is not "Engine", even not to null.
This makes sense since we always check the condition of "isIntellisenseV2" which validates the cluster type is "Engine".