### PR TITLE
chore: Added sanity tests to samples

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn build
 
       - name: Install Playwright deps
-        run: yarn playwright install webkit chromium firefox
+        run: yarn playwright install-deps
 
       - name: test samples
         run: yarn test:samples

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn build
 
       - name: Install Playwright deps
-        run: yarn playwright install-deps
+        run: yarn playwright install-deps chrome firefox webkit
 
       - name: test samples
         run: yarn test:samples

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,5 +25,8 @@ jobs:
         working-directory: package
         run: yarn build
 
+      - name: Install Playwright deps
+        run: yarn playwright install-deps
+
       - name: test samples
         run: yarn test:samples

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn build
 
       - name: Install Playwright deps
-        run: yarn playwright install-deps
+        run: yarn playwright install webkit chromium firefox
 
       - name: test samples
         run: yarn test:samples

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,8 +16,7 @@ jobs:
           cache: yarn
 
       - name: yarn install
-        run: |
-          yarn install --immutable
+        run: yarn install --immutable
 
       - name: Check formatting
         run: yarn format:check
@@ -25,3 +24,6 @@ jobs:
       - name: build
         working-directory: package
         run: yarn build
+
+      - name: test samples
+        run: yarn test:samples

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "license": "MIT",
     "scripts": {
         "format": "prettier --write .",
-        "format:check": "prettier --check ."
+        "format:check": "prettier --check .",
+        "test:samples": "ts-node ./scripts/test-samples.ts"
     },
     "workspaces": {
         "packages": [
@@ -16,8 +17,12 @@
     },
     "packageManager": "yarn@3.4.1",
     "devDependencies": {
+        "@types/wait-on": "^5.3.1",
+        "playwright": "^1.32.2",
         "prettier": "^2.8.4",
-        "process": "^0.11.10"
+        "process": "^0.11.10",
+        "ts-node": "^10.9.1",
+        "wait-on": "^7.0.1"
     },
     "resolutions": {
         "monaco-editor@~0.35.0": "patch:monaco-editor@npm%3A0.35.0#./.yarn/patches/monaco-editor-npm-0.35.0-f4a2faf37d.patch"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "playwright": "^1.32.2",
         "prettier": "^2.8.4",
         "process": "^0.11.10",
+        "tree-kill": "^1.2.2",
         "ts-node": "^10.9.1",
         "wait-on": "^7.0.1"
     },

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
         "@types/wait-on": "^5.3.1",
         "playwright": "^1.32.2",
         "prettier": "^2.8.4",
-        "process": "^0.11.10",
-        "tree-kill": "^1.2.2",
         "ts-node": "^10.9.1",
         "wait-on": "^7.0.1"
     },

--- a/samples/amd-webpack-react/package.json
+++ b/samples/amd-webpack-react/package.json
@@ -9,10 +9,12 @@
         "build:prod": "webpack --mode=production --node-env=production",
         "watch": "webpack --watch",
         "serve": "webpack serve",
-        "copy-amd-files": "copyMonacoFilesAMD ./public"
+        "copy-amd-files": "copyMonacoFilesAMD ./public",
+        "playwright:prepare": "yarn copy-amd-files",
+        "playwright:webserver": "webpack serve --port 3000 --no-open"
     },
     "dependencies": {
-        "@kusto/monaco-kusto": "6.1.1",
+        "@kusto/monaco-kusto": "workspace:*",
         "monaco-editor": "~0.35.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/samples/amd-webpack-react/src/index.js
+++ b/samples/amd-webpack-react/src/index.js
@@ -32,6 +32,14 @@ const schema = {
     },
 };
 
+// Called by playwright script in ci to validate things are working
+window.sanityCheck = async function () {
+    await new Promise((resolve) =>
+        __non_webpack_require__(['vs/editor/editor.main', 'vs/language/kusto/monaco.contribution'], () => resolve())
+    );
+    return !!(await monaco.languages.kusto.getKustoWorker());
+};
+
 function App() {
     const divRef = React.useRef(null);
 

--- a/samples/amd-webpack-react/src/index.js
+++ b/samples/amd-webpack-react/src/index.js
@@ -33,7 +33,7 @@ const schema = {
 };
 
 // Called by playwright script in ci to validate things are working
-window.sanityCheck = async function () {
+window.healthCheck = async function () {
     await new Promise((resolve) =>
         __non_webpack_require__(['vs/editor/editor.main', 'vs/language/kusto/monaco.contribution'], () => resolve())
     );

--- a/samples/amd/index.html
+++ b/samples/amd/index.html
@@ -18,6 +18,14 @@
         <div id="root"></div>
         <script src="./vs/loader.js"></script>
         <script>
+            // Called by playwright script in ci to validate things are working
+            window.sanityCheck = async function () {
+                await new Promise((resolve) =>
+                    require(['vs/editor/editor.main', 'vs/language/kusto/monaco.contribution'], () => resolve())
+                );
+                return !!(await monaco.languages.kusto.getKustoWorker());
+            };
+
             // 'vs/editor/editor.main' is not required here, but makes things
             // load a little faster. Without it, require.js won't start loading
             // it until after 'vs/language/kusto/monaco.contribution' is loaded

--- a/samples/amd/index.html
+++ b/samples/amd/index.html
@@ -19,7 +19,7 @@
         <script src="./vs/loader.js"></script>
         <script>
             // Called by playwright script in ci to validate things are working
-            window.sanityCheck = async function () {
+            window.healthCheck = async function () {
                 await new Promise((resolve) =>
                     require(['vs/editor/editor.main', 'vs/language/kusto/monaco.contribution'], () => resolve())
                 );

--- a/samples/amd/package.json
+++ b/samples/amd/package.json
@@ -3,12 +3,14 @@
     "version": "0.0.0",
     "private": true,
     "dependencies": {
-        "@kusto/monaco-kusto": "6.1.1",
+        "@kusto/monaco-kusto": "workspace:*",
         "monaco-editor": "~0.35.0"
     },
     "scripts": {
         "build": "copyMonacoFilesAMD .",
-        "start": "live-server ./"
+        "start": "live-server ./",
+        "playwright:prepare": "yarn build",
+        "playwright:webserver": "live-server --port=3000 --no-browser ./"
     },
     "devDependencies": {
         "live-server": "^1.2.2"

--- a/samples/parcel/index.tsx
+++ b/samples/parcel/index.tsx
@@ -6,12 +6,12 @@ import './index.css';
 
 declare global {
     interface Window {
-        sanityCheck(): Promise<boolean>;
+        healthCheck(): Promise<boolean>;
     }
 }
 
 // Called by playwright script in ci to validate things are working
-window.sanityCheck = async function () {
+window.healthCheck = async function () {
     return !!(await monaco.languages.kusto.getKustoWorker());
 };
 

--- a/samples/parcel/index.tsx
+++ b/samples/parcel/index.tsx
@@ -4,6 +4,17 @@ import '@kusto/monaco-kusto/release/esm/monaco.contribution';
 
 import './index.css';
 
+declare global {
+    interface Window {
+        sanityCheck(): Promise<boolean>;
+    }
+}
+
+// Called by playwright script in ci to validate things are working
+window.sanityCheck = async function () {
+    return !!(await monaco.languages.kusto.getKustoWorker());
+};
+
 const schema = {
     Plugins: [],
     Databases: {

--- a/samples/parcel/package.json
+++ b/samples/parcel/package.json
@@ -5,13 +5,14 @@
     "private": true,
     "scripts": {
         "start": "parcel index.html",
-        "build": "parcel build index.html"
+        "build": "parcel build index.html",
+        "playwright:webserver": "parcel index.html --port 3000"
     },
     "alias": {
         "./MonacoEnvironment.ts": "MonacoEnvironment"
     },
     "dependencies": {
-        "@kusto/monaco-kusto": "6.1.1",
+        "@kusto/monaco-kusto": "workspace:*",
         "monaco-editor": "~0.35.0",
         "react": "^16.13.0",
         "react-dom": "^16.13.1"

--- a/samples/parcel/package.json
+++ b/samples/parcel/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@kusto/monaco-kusto": "workspace:*",
         "monaco-editor": "~0.35.0",
+        "process": "^0.11.10",
         "react": "^16.13.0",
         "react-dom": "^16.13.1"
     },

--- a/scripts/test-samples.ts
+++ b/scripts/test-samples.ts
@@ -11,10 +11,6 @@ const samplesFolder = path.join(__dirname, '../samples');
 
 async function main() {
     for (const dir of readdirSync(samplesFolder)) {
-        // if (dir !== 'amd-webpack-react') {
-        //     continue;
-        // }
-
         const cwd = path.join(samplesFolder, dir);
 
         const pkg = JSON.parse(await fs.readFile(path.join(cwd, 'package.json'), { encoding: 'utf-8' }));

--- a/scripts/test-samples.ts
+++ b/scripts/test-samples.ts
@@ -11,6 +11,10 @@ const samplesFolder = path.join(__dirname, '../samples');
 
 async function main() {
     for (const dir of readdirSync(samplesFolder)) {
+        // if (dir !== 'amd-webpack-react') {
+        //     continue;
+        // }
+
         const cwd = path.join(samplesFolder, dir);
 
         const pkg = JSON.parse(await fs.readFile(path.join(cwd, 'package.json'), { encoding: 'utf-8' }));
@@ -30,7 +34,7 @@ async function main() {
             webserver.stdout?.pipe(process.stdout);
 
             console.log('Waiting for webserver to start');
-            await waitOn({ resources: ['http://localhost:3000'] });
+            await waitOn({ resources: ['http://localhost:3000'], timeout: 10_000 });
 
             for (const browserType of [chromium, firefox, webkit]) {
                 console.log('samples/' + dir + ' ' + browserType.name());
@@ -47,11 +51,11 @@ async function main() {
                 await browser.close();
             }
         } finally {
-            webserver.kill(9);
+            webserver.kill();
         }
         // Webserver takes a moment to close after kill signal is sent
         console.log('Waiting for webserver to stop');
-        await waitOn({ resources: ['http://localhost:3000'], reverse: true });
+        // await waitOn({ resources: ['http://localhost:3000'], reverse: true, timeout: 3000 });
     }
 }
 

--- a/scripts/test-samples.ts
+++ b/scripts/test-samples.ts
@@ -46,6 +46,7 @@ async function main() {
         } finally {
             webserver.kill();
         }
+        await waitOn({ resources: ['http://localhost:3000'], reverse: true });
     }
 }
 

--- a/scripts/test-samples.ts
+++ b/scripts/test-samples.ts
@@ -1,0 +1,52 @@
+import { readdirSync } from 'node:fs';
+import cp from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import assert from 'node:assert';
+
+import waitOn from 'wait-on';
+import { chromium, firefox, webkit } from 'playwright';
+
+const samplesFolder = path.join(__dirname, '../samples');
+
+async function main() {
+    for (const dir of readdirSync(samplesFolder)) {
+        const cwd = path.join(samplesFolder, dir);
+
+        const pkg = JSON.parse(await fs.readFile(path.join(cwd, 'package.json'), { encoding: 'utf-8' }));
+
+        if ('playwright:prepare' in pkg.scripts) {
+            cp.execSync('yarn playwright:prepare', { cwd, stdio: 'inherit' });
+        }
+
+        const webserver = cp.exec('yarn playwright:webserver', { cwd }, (err) => {
+            if (err && !err.killed) {
+                throw err;
+            }
+        });
+
+        try {
+            webserver.stderr?.pipe(process.stderr);
+            webserver.stdout?.pipe(process.stdout);
+
+            await waitOn({ resources: ['http://localhost:3000'] });
+
+            for (const browserType of [chromium, firefox, webkit]) {
+                console.log('samples/' + dir + ' ' + browserType.name());
+
+                const browser = await browserType.launch();
+                const page = await browser.newPage();
+
+                await page.goto('localhost:3000');
+
+                assert(await page.evaluate('sanityCheck()'));
+
+                await browser.close();
+            }
+        } finally {
+            webserver.kill();
+        }
+    }
+}
+
+main();

--- a/scripts/test-samples.ts
+++ b/scripts/test-samples.ts
@@ -5,7 +5,6 @@ import path from 'node:path';
 import assert from 'node:assert';
 
 import waitOn from 'wait-on';
-import treeKill from 'tree-kill';
 import { chromium, firefox, webkit } from 'playwright';
 
 const samplesFolder = path.join(__dirname, '../samples');
@@ -20,10 +19,9 @@ async function main() {
             cp.execSync('yarn playwright:prepare', { cwd, stdio: 'inherit' });
         }
 
+        // Running with cp.exec causes us to be unable to easily close some
+        // webservers in CI
         const webserver = cp.spawn('yarn', ['playwright:webserver'], { cwd, stdio: 'inherit' });
-
-        // webserver.stderr?.pipe(process.stderr);
-        // webserver.stdout?.pipe(process.stdout);
 
         console.log('Waiting for webserver to start');
         await waitOn({ resources: ['http://localhost:3000'], timeout: 120_000 });
@@ -48,9 +46,6 @@ async function main() {
         });
 
         webserver.kill();
-
-        // worker.kill() wasn't working in ci
-        // await new Promise((resolve) => treeKill(webserver.pid!, 'SIGTERM', resolve));
 
         // Webserver takes a moment to close after kill signal is sent
         console.log('Waiting for webserver to stop');

--- a/scripts/test-samples.ts
+++ b/scripts/test-samples.ts
@@ -29,6 +29,7 @@ async function main() {
             webserver.stderr?.pipe(process.stderr);
             webserver.stdout?.pipe(process.stdout);
 
+            console.log('Waiting for webserver to start');
             await waitOn({ resources: ['http://localhost:3000'] });
 
             for (const browserType of [chromium, firefox, webkit]) {
@@ -41,11 +42,15 @@ async function main() {
 
                 assert(await page.evaluate('sanityCheck()'));
 
+                console.log('Sanity check passed!');
+
                 await browser.close();
             }
         } finally {
-            webserver.kill();
+            webserver.kill(9);
         }
+        // Webserver takes a moment to close after kill signal is sent
+        console.log('Waiting for webserver to stop');
         await waitOn({ resources: ['http://localhost:3000'], reverse: true });
     }
 }

--- a/scripts/test-samples.ts
+++ b/scripts/test-samples.ts
@@ -20,14 +20,10 @@ async function main() {
             cp.execSync('yarn playwright:prepare', { cwd, stdio: 'inherit' });
         }
 
-        const webserver = cp.exec('yarn playwright:webserver', { cwd }, (err) => {
-            if (err) {
-                console.log(err);
-            }
-        });
+        const webserver = cp.spawn('yarn', ['playwright:webserver'], { cwd, stdio: 'inherit' });
 
-        webserver.stderr?.pipe(process.stderr);
-        webserver.stdout?.pipe(process.stdout);
+        // webserver.stderr?.pipe(process.stderr);
+        // webserver.stdout?.pipe(process.stdout);
 
         console.log('Waiting for webserver to start');
         await waitOn({ resources: ['http://localhost:3000'], timeout: 120_000 });
@@ -47,13 +43,14 @@ async function main() {
             await browser.close();
         }
 
-        // webserver.kill();
-
         const exited = new Promise((resolve) => {
             webserver.on('close', resolve);
         });
 
-        await new Promise((resolve) => treeKill(webserver.pid!, 'SIGTERM', resolve));
+        webserver.kill();
+
+        // worker.kill() wasn't working in ci
+        // await new Promise((resolve) => treeKill(webserver.pid!, 'SIGTERM', resolve));
 
         // Webserver takes a moment to close after kill signal is sent
         console.log('Waiting for webserver to stop');

--- a/yarn.lock
+++ b/yarn.lock
@@ -6678,6 +6678,7 @@ __metadata:
     "@types/react-dom": ^16.8.4
     monaco-editor: ~0.35.0
     parcel: ^2.0.0
+    process: ^0.11.10
     react: ^16.13.0
     react-dom: ^16.13.1
     typescript: ^4.3.3
@@ -7515,6 +7516,13 @@ __metadata:
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
   checksum: 1d38588e520dab7cea67cbbe2efdd86a10cc7a074c09657635e34f035277b59fbb57d09d8638346bf7090f8e8ebc070c96fa5fd183b777fff4f5edff5e9466cf
+  languageName: node
+  linkType: hard
+
+"process@npm:^0.11.10":
+  version: 0.11.10
+  resolution: "process@npm:0.11.10"
+  checksum: bfcce49814f7d172a6e6a14d5fa3ac92cc3d0c3b9feb1279774708a719e19acd673995226351a082a9ae99978254e320ccda4240ddc474ba31a76c79491ca7c3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6692,6 +6692,7 @@ __metadata:
     playwright: ^1.32.2
     prettier: ^2.8.4
     process: ^0.11.10
+    tree-kill: ^1.2.2
     ts-node: ^10.9.1
     wait-on: ^7.0.1
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -1410,6 +1410,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hapi/hoek@npm:^9.0.0":
+  version: 9.3.0
+  resolution: "@hapi/hoek@npm:9.3.0"
+  checksum: 4771c7a776242c3c022b168046af4e324d116a9d2e1d60631ee64f474c6e38d1bb07092d898bf95c7bc5d334c5582798a1456321b2e53ca817d4e7c88bc25b43
+  languageName: node
+  linkType: hard
+
+"@hapi/topo@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "@hapi/topo@npm:5.1.0"
+  dependencies:
+    "@hapi/hoek": ^9.0.0
+  checksum: 604dfd5dde76d5c334bd03f9001fce69c7ce529883acf92da96f4fe7e51221bf5e5110e964caca287a6a616ba027c071748ab636ff178ad750547fba611d6014
+  languageName: node
+  linkType: hard
+
 "@jridgewell/gen-mapping@npm:^0.1.0":
   version: 0.1.1
   resolution: "@jridgewell/gen-mapping@npm:0.1.1"
@@ -1496,7 +1512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kusto/monaco-kusto@6.1.1, @kusto/monaco-kusto@workspace:package":
+"@kusto/monaco-kusto@workspace:*, @kusto/monaco-kusto@workspace:package":
   version: 0.0.0-use.local
   resolution: "@kusto/monaco-kusto@workspace:package"
   dependencies:
@@ -2484,6 +2500,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sideway/address@npm:^4.1.3":
+  version: 4.1.4
+  resolution: "@sideway/address@npm:4.1.4"
+  dependencies:
+    "@hapi/hoek": ^9.0.0
+  checksum: b9fca2a93ac2c975ba12e0a6d97853832fb1f4fb02393015e012b47fa916a75ca95102d77214b2a29a2784740df2407951af8c5dde054824c65577fd293c4cdb
+  languageName: node
+  linkType: hard
+
+"@sideway/formula@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@sideway/formula@npm:3.0.1"
+  checksum: e4beeebc9dbe2ff4ef0def15cec0165e00d1612e3d7cea0bc9ce5175c3263fc2c818b679bd558957f49400ee7be9d4e5ac90487e1625b4932e15c4aa7919c57a
+  languageName: node
+  linkType: hard
+
+"@sideway/pinpoint@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@sideway/pinpoint@npm:2.0.0"
+  checksum: 0f4491e5897fcf5bf02c46f5c359c56a314e90ba243f42f0c100437935daa2488f20482f0f77186bd6bf43345095a95d8143ecf8b1f4d876a7bc0806aba9c3d2
+  languageName: node
+  linkType: hard
+
 "@swc/helpers@npm:^0.4.12":
   version: 0.4.14
   resolution: "@swc/helpers@npm:0.4.14"
@@ -2784,6 +2823,15 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: b9bbb2b5c5ead2fb884bb019f61a014e37410bddd295de28184e1b2e71ee6b04120c5ba7b9954617f0bdf962c13d06249ce65004490889c747c80d3f628ea842
+  languageName: node
+  linkType: hard
+
+"@types/wait-on@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "@types/wait-on@npm:5.3.1"
+  dependencies:
+    "@types/node": "*"
+  checksum: 2a6e88a107930963ceea016dc733dc259dc52faf864933cd4d6f7fc6db7165254c10f8bfcb3b803237b2869674d988319ea4f958c0b6fd3763c5fcb9e489565a
   languageName: node
   linkType: hard
 
@@ -3299,12 +3347,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"asynckit@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "asynckit@npm:0.4.0"
+  checksum: 7b78c451df768adba04e2d02e63e2d0bf3b07adcd6e42b4cf665cb7ce899bedd344c69a1dcbce355b5f972d597b25aaa1c1742b52cffd9caccb22f348114f6be
+  languageName: node
+  linkType: hard
+
 "atob@npm:^2.1.2":
   version: 2.1.2
   resolution: "atob@npm:2.1.2"
   bin:
     atob: bin/atob.js
   checksum: dfeeeb70090c5ebea7be4b9f787f866686c645d9f39a0d184c817252d0cf08455ed25267d79c03254d3be1f03ac399992a792edcd5ffb9c91e097ab5ef42833a
+  languageName: node
+  linkType: hard
+
+"axios@npm:^0.27.2":
+  version: 0.27.2
+  resolution: "axios@npm:0.27.2"
+  dependencies:
+    follow-redirects: ^1.14.9
+    form-data: ^4.0.0
+  checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
   languageName: node
   linkType: hard
 
@@ -3844,6 +3909,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"combined-stream@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "combined-stream@npm:1.0.8"
+  dependencies:
+    delayed-stream: ~1.0.0
+  checksum: 49fa4aeb4916567e33ea81d088f6584749fc90c7abec76fd516bf1c5aa5c79f3584b5ba3de6b86d26ddd64bae5329c4c7479343250cfe71c75bb366eae53bb7c
+  languageName: node
+  linkType: hard
+
 "commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
@@ -4243,6 +4317,13 @@ __metadata:
     is-descriptor: ^1.0.2
     isobject: ^3.0.1
   checksum: 3217ed53fc9eed06ba8da6f4d33e28c68a82e2f2a8ab4d562c4920d8169a166fe7271453675e6c69301466f36a65d7f47edf0cf7f474b9aa52a5ead9c1b13c99
+  languageName: node
+  linkType: hard
+
+"delayed-stream@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "delayed-stream@npm:1.0.0"
+  checksum: 46fe6e83e2cb1d85ba50bd52803c68be9bd953282fa7096f51fc29edd5d67ff84ff753c51966061e5ba7cb5e47ef6d36a91924eddb7f3f3483b1c560f77a0020
   languageName: node
   linkType: hard
 
@@ -4824,7 +4905,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.9":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
@@ -4838,6 +4919,17 @@ __metadata:
   version: 1.0.2
   resolution: "for-in@npm:1.0.2"
   checksum: 09f4ae93ce785d253ac963d94c7f3432d89398bf25ac7a24ed034ca393bf74380bdeccc40e0f2d721a895e54211b07c8fad7132e8157827f6f7f059b70b4043d
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    mime-types: ^2.1.12
+  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
   languageName: node
   linkType: hard
 
@@ -5860,6 +5952,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"joi@npm:^17.7.0":
+  version: 17.9.1
+  resolution: "joi@npm:17.9.1"
+  dependencies:
+    "@hapi/hoek": ^9.0.0
+    "@hapi/topo": ^5.0.0
+    "@sideway/address": ^4.1.3
+    "@sideway/formula": ^3.0.1
+    "@sideway/pinpoint": ^2.0.0
+  checksum: 055df3841e00d7ed065ef1cc3330cf69097ab2ffec3083d8b1d6edfd2e25504bf2983f5249d6f0459bcad99fe21bb0c9f6f1cc03569713af27cd5eb00ee7bb7d
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -6346,7 +6451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:~2.1.17, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:~2.1.17, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -6405,7 +6510,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.1.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
+"minimist@npm:^1.1.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6, minimist@npm:^1.2.7":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
@@ -6537,7 +6642,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "monaco-kusto--AMD-example@workspace:samples/amd"
   dependencies:
-    "@kusto/monaco-kusto": 6.1.1
+    "@kusto/monaco-kusto": "workspace:*"
     live-server: ^1.2.2
     monaco-editor: ~0.35.0
   languageName: unknown
@@ -6550,7 +6655,7 @@ __metadata:
     "@babel/core": ^7.21.4
     "@babel/preset-env": ^7.21.4
     "@babel/preset-react": ^7.18.6
-    "@kusto/monaco-kusto": 6.1.1
+    "@kusto/monaco-kusto": "workspace:*"
     babel-loader: ^9.1.2
     css-loader: ^6.7.3
     html-webpack-plugin: ^5.5.0
@@ -6568,7 +6673,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "monaco-kusto--esm-parcel-example@workspace:samples/parcel"
   dependencies:
-    "@kusto/monaco-kusto": 6.1.1
+    "@kusto/monaco-kusto": "workspace:*"
     "@types/react": ^16.9.11
     "@types/react-dom": ^16.8.4
     monaco-editor: ~0.35.0
@@ -6583,8 +6688,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "monaco-kusto@workspace:."
   dependencies:
+    "@types/wait-on": ^5.3.1
+    playwright: ^1.32.2
     prettier: ^2.8.4
     process: ^0.11.10
+    ts-node: ^10.9.1
+    wait-on: ^7.0.1
   languageName: unknown
   linkType: soft
 
@@ -7237,6 +7346,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.32.2":
+  version: 1.32.2
+  resolution: "playwright-core@npm:1.32.2"
+  bin:
+    playwright: cli.js
+  checksum: ff000cbf280e5d558fe70fd3edf14910a2e86ec68b04e28327176268345be7b3f88a5d22d78e8dae677dd633dce6cd493237df199773b55312f2ae1ab85d711f
+  languageName: node
+  linkType: hard
+
+"playwright@npm:^1.32.2":
+  version: 1.32.2
+  resolution: "playwright@npm:1.32.2"
+  dependencies:
+    playwright-core: 1.32.2
+  bin:
+    playwright: cli.js
+  checksum: 36967299a5c4c02830bcb7fb94b96d6c6a7a2d7e749feb924509e89b1fdc34f8ee2218cfaf75e5f32572663568b468ad28fdc170bced41869d5ed69f9a7ff384
+  languageName: node
+  linkType: hard
+
 "portfinder@npm:^1.0.25":
   version: 1.0.32
   resolution: "portfinder@npm:1.0.32"
@@ -7859,7 +7988,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.0.0":
+"rxjs@npm:^7.0.0, rxjs@npm:^7.8.0":
   version: 7.8.0
   resolution: "rxjs@npm:7.8.0"
   dependencies:
@@ -8938,6 +9067,21 @@ __metadata:
   version: 3.16.0
   resolution: "vscode-languageserver-types@npm:3.16.0"
   checksum: 7a44fb10b9fbeb9529f832337b7f0430fc6275d62945b86851d425a950e22da3917ef5f6c552688191769dd1eae047c6ee9ec3d9f2280498353007c2dfe0725c
+  languageName: node
+  linkType: hard
+
+"wait-on@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "wait-on@npm:7.0.1"
+  dependencies:
+    axios: ^0.27.2
+    joi: ^17.7.0
+    lodash: ^4.17.21
+    minimist: ^1.2.7
+    rxjs: ^7.8.0
+  bin:
+    wait-on: bin/wait-on
+  checksum: 1e8a17d8ee6436f71d3ab82781ce31267481fcd7bbccde49b0f8124871e6e40a1acac3401f04f775ba6203853a5813352fa131620fc139914351f3b2894d573f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6691,8 +6691,6 @@ __metadata:
     "@types/wait-on": ^5.3.1
     playwright: ^1.32.2
     prettier: ^2.8.4
-    process: ^0.11.10
-    tree-kill: ^1.2.2
     ts-node: ^10.9.1
     wait-on: ^7.0.1
   languageName: unknown
@@ -7517,13 +7515,6 @@ __metadata:
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
   checksum: 1d38588e520dab7cea67cbbe2efdd86a10cc7a074c09657635e34f035277b59fbb57d09d8638346bf7090f8e8ebc070c96fa5fd183b777fff4f5edff5e9466cf
-  languageName: node
-  linkType: hard
-
-"process@npm:^0.11.10":
-  version: 0.11.10
-  resolution: "process@npm:0.11.10"
-  checksum: bfcce49814f7d172a6e6a14d5fa3ac92cc3d0c3b9feb1279774708a719e19acd673995226351a082a9ae99978254e320ccda4240ddc474ba31a76c79491ca7c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tests are written with Playwright directly, not using @playwright/test. This is because when writing Playwright tests, the webserver config is global, not per-test.

Playwright script starts the dev servers for each sample, and then calls a "heathCheck" function each of them have defined.

Renamed "build" ci workflow to "pr" because it now includes testing.