### PR TITLE
chore: Update Parcel example to work around Parcel bug

### DIFF
--- a/samples/parcel/index.html
+++ b/samples/parcel/index.html
@@ -9,27 +9,12 @@
 
     <body>
         <div id="root"></div>
-
-        <!--
-            This is here because MonacoEnvironment.globalAPI needs to be set
-            before `monaco-kusto` is parsed, which wasn't happening when it
-            was in ./src/index.ts
-
-            See ./README.md for more details
-        -->
-        <script type="module">
-            import kustoWorkerUrl from 'url:@kusto/monaco-kusto/release/esm/kusto.worker';
-            import editorWorkerUrl from 'url:monaco-editor/esm/vs/editor/editor.worker';
-
-            self.MonacoEnvironment = {
-                globalAPI: true,
-                getWorkerUrl(_moduleId, label) {
-                    if (label === 'kusto') {
-                        return kustoWorkerUrl;
-                    }
-                    return editorWorkerUrl;
-                },
-            };
+        <script>
+            // This is here because MonacoEnvironment.globalAPI needs to be set
+            // before `monaco-kusto` is parsed, which wasn't happening when it
+            // was in ./src/index.ts
+            // See ./README.md for more details
+            self.MonacoEnvironment = { globalAPI: true };
         </script>
         <script type="module" src="./index.tsx"></script>
     </body>

--- a/samples/parcel/index.tsx
+++ b/samples/parcel/index.tsx
@@ -1,4 +1,6 @@
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import kustoWorkerUrl from 'url:@kusto/monaco-kusto/release/esm/kusto.worker';
+import editorWorkerUrl from 'url:monaco-editor/esm/vs/editor/editor.worker';
 
 import '@kusto/monaco-kusto/release/esm/monaco.contribution';
 
@@ -13,6 +15,15 @@ declare global {
 // Called by playwright script in ci to validate things are working
 window.healthCheck = async function () {
     return !!(await monaco.languages.kusto.getKustoWorker());
+};
+
+// Can't set this in index.html because of a Parcel bug related to `url:*`
+// imports in html files: https://github.com/parcel-bundler/parcel/issues/8900
+self.MonacoEnvironment!.getWorkerUrl = function (_moduleId, label) {
+    if (label === 'kusto') {
+        return kustoWorkerUrl;
+    }
+    return editorWorkerUrl;
 };
 
 const schema = {

--- a/samples/parcel/package.json
+++ b/samples/parcel/package.json
@@ -8,9 +8,6 @@
         "build": "parcel build index.html",
         "playwright:webserver": "parcel index.html --port 3000"
     },
-    "alias": {
-        "./MonacoEnvironment.ts": "MonacoEnvironment"
-    },
     "dependencies": {
         "@kusto/monaco-kusto": "workspace:*",
         "monaco-editor": "~0.35.0",


### PR DESCRIPTION
Update Parcel example to work around Parcel bug related to `url:*` imports in the index.html file.

https://github.com/parcel-bundler/parcel/issues/8900