### PR TITLE
Added types back to global api

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ There are 2 APIs to set a Kusto schema:
 
 ## Changelog
 
+### 7.2.1
+
+-   fix: Added types back to global api
+
 ### 7.2.0
 
 -   Added "themeNames" object to exports which contains the theme we register with monaco: kusto-light, kusto-dark, and kusto-dark2

--- a/package/globalApi.d.ts
+++ b/package/globalApi.d.ts
@@ -1,4 +1,5 @@
-// Augments monaco global types with Kusto api. Should be imported if you're using amd modules, or if you've set `MonacoEnvironment.globalApi` to true.
+// Augments monaco global types with Kusto api. Should be imported if you're
+// using amd modules, or if you've set `MonacoEnvironment.globalApi` to true.
 
 /// <reference types="monaco-editor/monaco" />
 
@@ -8,6 +9,44 @@ declare namespace monaco.editor {
     }
 }
 
+// No easy way to declare a namespace that matches an existing module right
+// now
+// https://github.com/microsoft/TypeScript/issues/10187
+
+// Export everything but the types
 declare namespace monaco.languages {
     export const kusto: typeof import('@kusto/monaco-kusto');
+}
+
+// Types must be manually re-exported right now :(
+declare namespace monaco.languages.kusto {
+    export type LanguageSettings = import('@kusto/monaco-kusto').LanguageSettings;
+    export type SyntaxErrorAsMarkDownOptions = import('@kusto/monaco-kusto').SyntaxErrorAsMarkDownOptions;
+    export type QuickFixCodeActionOptions = import('@kusto/monaco-kusto').QuickFixCodeActionOptions;
+    export type FormatterOptions = import('@kusto/monaco-kusto').FormatterOptions;
+    export type FormatterPlacementStyle = import('@kusto/monaco-kusto').FormatterPlacementStyle;
+    export type LanguageServiceDefaults = import('@kusto/monaco-kusto').LanguageServiceDefaults;
+    export type KustoWorker = import('@kusto/monaco-kusto').KustoWorker;
+    export type WorkerAccessor = import('@kusto/monaco-kusto').WorkerAccessor;
+    export type Column = import('@kusto/monaco-kusto').Column;
+    export type Table = import('@kusto/monaco-kusto').Table;
+    export type ScalarParameter = import('@kusto/monaco-kusto').ScalarParameter;
+    export type TabularParameter = import('@kusto/monaco-kusto').TabularParameter;
+    export type InputParameter = import('@kusto/monaco-kusto').InputParameter;
+    export type Function = import('@kusto/monaco-kusto').Function;
+    export type Database = import('@kusto/monaco-kusto').Database;
+    export type EngineSchema = import('@kusto/monaco-kusto').EngineSchema;
+    export type ClusterMangerSchema = import('@kusto/monaco-kusto').ClusterMangerSchema;
+    export type DataManagementSchema = import('@kusto/monaco-kusto').DataManagementSchema;
+    export type Schema = import('@kusto/monaco-kusto').Schema;
+    export type VisualizationType = import('@kusto/monaco-kusto').VisualizationType;
+    export type Scale = import('@kusto/monaco-kusto').Scale;
+    export type LegendVisibility = import('@kusto/monaco-kusto').LegendVisibility;
+    export type YSplit = import('@kusto/monaco-kusto').YSplit;
+    export type Kind = import('@kusto/monaco-kusto').Kind;
+    export type RenderOptions = import('@kusto/monaco-kusto').RenderOptions;
+    export type RenderInfo = import('@kusto/monaco-kusto').RenderInfo;
+    export type DatabaseReference = import('@kusto/monaco-kusto').DatabaseReference;
+    export type ClusterReference = import('@kusto/monaco-kusto').ClusterReference;
+    export type OnDidProvideCompletionItems = import('@kusto/monaco-kusto').OnDidProvideCompletionItems;
 }

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "7.2.0",
+    "version": "7.2.1",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/samples/amd-webpack-react/src/index.tsx
+++ b/samples/amd-webpack-react/src/index.tsx
@@ -67,7 +67,7 @@ function App() {
                 theme: 'kusto-light',
             });
 
-            monaco.languages.kusto.getKustoWorker().then((workerAccessor) => {
+            monaco.languages.kusto.getKustoWorker().then((workerAccessor: monaco.languages.kusto.WorkerAccessor) => {
                 if (disposed) {
                     return;
                 }
@@ -75,7 +75,7 @@ function App() {
                 if (!model) {
                     return;
                 }
-                workerAccessor(model.uri).then((worker) => {
+                workerAccessor(model.uri).then((worker: monaco.languages.kusto.KustoWorker) => {
                     if (disposed) {
                         return;
                     }


### PR DESCRIPTION
When I moved the types to /src out of the global api I didn't test it well enough and the _types_ types we're re-exported. There isn't a good way to re-export these, so I had to do each of them by hand.

I've also added some references to them to the amd typescript sample to catch any future regression.
