### PR TITLE
fix: Parcel example doesn't work with new monaco-editor versions

### DIFF
--- a/.yarn/patches/monaco-editor-npm-0.46.0-fb69b10c11.patch
+++ b/.yarn/patches/monaco-editor-npm-0.46.0-fb69b10c11.patch
@@ -1,0 +1,18 @@
+diff --git a/esm/vs/base/common/platform.js b/esm/vs/base/common/platform.js
+index d507327daec3cdf5027bd886f898c364c5433ecd..9dc769654606b60bc71922dd40f2146db97dcbb9 100644
+--- a/esm/vs/base/common/platform.js
++++ b/esm/vs/base/common/platform.js
+@@ -26,9 +26,11 @@ if (typeof $globalThis.vscode !== 'undefined' && typeof $globalThis.vscode.proce
+     // Native environment (sandboxed)
+     nodeProcess = $globalThis.vscode.process;
+ }
+-else if (typeof process !== 'undefined') {
++// Work around bug in Parcel causing $globalThis.process !== process
++// https://github.com/parcel-bundler/parcel/issues/9549
++else if (typeof $globalThis.process !== 'undefined') {
+     // Native environment (non-sandboxed)
+-    nodeProcess = process;
++    nodeProcess = $globalThis.process;
+ }
+ const isElectronProcess = typeof ((_a = nodeProcess === null || nodeProcess === void 0 ? void 0 : nodeProcess.versions) === null || _a === void 0 ? void 0 : _a.electron) === 'string';
+ const isElectronRenderer = isElectronProcess && (nodeProcess === null || nodeProcess === void 0 ? void 0 : nodeProcess.type) === 'renderer';

--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2",
         "wait-on": "^7.0.1"
+    },
+    "resolutions": {
+        "monaco-editor@^0.46.0": "patch:monaco-editor@npm%3A0.46.0#./.yarn/patches/monaco-editor-npm-0.46.0-fb69b10c11.patch",
+        "monaco-editor@~0.46.0": "patch:monaco-editor@npm%3A0.46.0#./.yarn/patches/monaco-editor-npm-0.46.0-fb69b10c11.patch"
     }
 }

--- a/samples/amd-webpack-react-cross-origin/package.json
+++ b/samples/amd-webpack-react-cross-origin/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@kusto/monaco-kusto": "workspace:*",
         "express": "^4.18.2",
-        "monaco-editor": "~0.45.0",
+        "monaco-editor": "~0.46.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/samples/esm-parcel/README.md
+++ b/samples/esm-parcel/README.md
@@ -1,3 +1,18 @@
 # Monaco Kusto Parcel example
 
 See [../../README.md] for general esm setup instructions
+
+## Parcel-specific changes
+
+### Add `{ "alias": { "process": false } }` to `package.json`
+
+@kusto/language-server includes node-specific code. Configure Parcel avoiding including `node_modules/process` in our bundle.
+
+Parcel docs on disabling `process` shimming: https://parceljs.org/features/dependency-resolution/#package-aliases
+Parcel docs on shimming globals: https://parceljs.org/features/node-emulation/#shimming-builtin-node-globals
+
+### Patch monaco-editor to use globalThis.process instead of process
+
+Recent monaco versions use `typeof process` to check if it's running in a node environment. Parcel doesn't have the ability to make this check return `false` so we need to patch monaco to use `globalThis.process` instead.
+
+Parcel issue tracking this: https://github.com/parcel-bundler/parcel/issues/9549

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,17 +15,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.22.13":
-  version: 7.22.13
-  resolution: "@babel/code-frame@npm:7.22.13"
-  dependencies:
-    "@babel/highlight": ^7.22.13
-    chalk: ^2.4.2
-  checksum: 22e342c8077c8b77eeb11f554ecca2ba14153f707b85294fcf6070b6f6150aae88a7b7436dd88d8c9289970585f3fe5b9b941c5aa3aa26a6d5a8ef3f292da058
-  languageName: node
-  linkType: hard
-
-"@babel/code-frame@npm:^7.23.5":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.22.13, @babel/code-frame@npm:^7.23.5":
   version: 7.23.5
   resolution: "@babel/code-frame@npm:7.23.5"
   dependencies:
@@ -65,19 +55,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.22.15":
-  version: 7.22.15
-  resolution: "@babel/generator@npm:7.22.15"
-  dependencies:
-    "@babel/types": ^7.22.15
-    "@jridgewell/gen-mapping": ^0.3.2
-    "@jridgewell/trace-mapping": ^0.3.17
-    jsesc: ^2.5.1
-  checksum: 5b2a3ccdc3634f6ea86e0a442722bcd430238369432d31f15b428a4ee8013c2f4f917b5b135bf4fc1d0a3e2f87f10fd4ce5d07955ecc2d3b9400a05c2a481374
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.23.5":
+"@babel/generator@npm:^7.22.15, @babel/generator@npm:^7.23.5":
   version: 7.23.5
   resolution: "@babel/generator@npm:7.23.5"
   dependencies:
@@ -174,17 +152,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-function-name@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/helper-function-name@npm:7.22.5"
-  dependencies:
-    "@babel/template": ^7.22.5
-    "@babel/types": ^7.22.5
-  checksum: 6b1f6ce1b1f4e513bf2c8385a557ea0dd7fa37971b9002ad19268ca4384bbe90c09681fe4c076013f33deabc63a53b341ed91e792de741b4b35e01c00238177a
-  languageName: node
-  linkType: hard
-
-"@babel/helper-function-name@npm:^7.23.0":
+"@babel/helper-function-name@npm:^7.22.5, @babel/helper-function-name@npm:^7.23.0":
   version: 7.23.0
   resolution: "@babel/helper-function-name@npm:7.23.0"
   dependencies:
@@ -305,13 +273,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-string-parser@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/helper-string-parser@npm:7.22.5"
-  checksum: 836851ca5ec813077bbb303acc992d75a360267aa3b5de7134d220411c852a6f17de7c0d0b8c8dcc0f567f67874c00f4528672b2a4f1bc978a3ada64c8c78467
-  languageName: node
-  linkType: hard
-
 "@babel/helper-string-parser@npm:^7.23.4":
   version: 7.23.4
   resolution: "@babel/helper-string-parser@npm:7.23.4"
@@ -319,7 +280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.22.19, @babel/helper-validator-identifier@npm:^7.22.20, @babel/helper-validator-identifier@npm:^7.22.5":
+"@babel/helper-validator-identifier@npm:^7.22.20, @babel/helper-validator-identifier@npm:^7.22.5":
   version: 7.22.20
   resolution: "@babel/helper-validator-identifier@npm:7.22.20"
   checksum: 136412784d9428266bcdd4d91c32bcf9ff0e8d25534a9d94b044f77fe76bc50f941a90319b05aafd1ec04f7d127cd57a179a3716009ff7f3412ef835ada95bdc
@@ -355,17 +316,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/highlight@npm:^7.22.13":
-  version: 7.22.20
-  resolution: "@babel/highlight@npm:7.22.20"
-  dependencies:
-    "@babel/helper-validator-identifier": ^7.22.20
-    chalk: ^2.4.2
-    js-tokens: ^4.0.0
-  checksum: 84bd034dca309a5e680083cd827a766780ca63cef37308404f17653d32366ea76262bd2364b2d38776232f2d01b649f26721417d507e8b4b6da3e4e739f6d134
-  languageName: node
-  linkType: hard
-
 "@babel/highlight@npm:^7.23.4":
   version: 7.23.4
   resolution: "@babel/highlight@npm:7.23.4"
@@ -377,16 +327,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.22.15, @babel/parser@npm:^7.22.16":
-  version: 7.22.16
-  resolution: "@babel/parser@npm:7.22.16"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 944c756b5bdeb07b9fec16ecef6b3c61aff9d4c4b924abadcf01afa1840a740b8e2357ae00482b5b37daad6d2bfd848c947f27ad65138d687b6fdc924bc59edd
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.23.5":
+"@babel/parser@npm:^7.22.15, @babel/parser@npm:^7.22.16, @babel/parser@npm:^7.23.5":
   version: 7.23.5
   resolution: "@babel/parser@npm:7.23.5"
   bin:
@@ -1481,18 +1422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.22.5, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
-  version: 7.22.19
-  resolution: "@babel/types@npm:7.22.19"
-  dependencies:
-    "@babel/helper-string-parser": ^7.22.5
-    "@babel/helper-validator-identifier": ^7.22.19
-    to-fast-properties: ^2.0.0
-  checksum: 2d69740e69b55ba36ece0c17d5afb7b7213b34297157df39ef9ba24965aff677c56f014413052ecc5b2fbbf26910c63e5bb24a969df84d7a17153750cf75915e
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.23.0, @babel/types@npm:^7.23.5":
+"@babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.23.5, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.23.5
   resolution: "@babel/types@npm:7.23.5"
   dependencies:
@@ -1865,44 +1795,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lmdb/lmdb-darwin-arm64@npm:2.7.11":
-  version: 2.7.11
-  resolution: "@lmdb/lmdb-darwin-arm64@npm:2.7.11"
+"@lmdb/lmdb-darwin-arm64@npm:2.8.5":
+  version: 2.8.5
+  resolution: "@lmdb/lmdb-darwin-arm64@npm:2.8.5"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@lmdb/lmdb-darwin-x64@npm:2.7.11":
-  version: 2.7.11
-  resolution: "@lmdb/lmdb-darwin-x64@npm:2.7.11"
+"@lmdb/lmdb-darwin-x64@npm:2.8.5":
+  version: 2.8.5
+  resolution: "@lmdb/lmdb-darwin-x64@npm:2.8.5"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@lmdb/lmdb-linux-arm64@npm:2.7.11":
-  version: 2.7.11
-  resolution: "@lmdb/lmdb-linux-arm64@npm:2.7.11"
+"@lmdb/lmdb-linux-arm64@npm:2.8.5":
+  version: 2.8.5
+  resolution: "@lmdb/lmdb-linux-arm64@npm:2.8.5"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@lmdb/lmdb-linux-arm@npm:2.7.11":
-  version: 2.7.11
-  resolution: "@lmdb/lmdb-linux-arm@npm:2.7.11"
+"@lmdb/lmdb-linux-arm@npm:2.8.5":
+  version: 2.8.5
+  resolution: "@lmdb/lmdb-linux-arm@npm:2.8.5"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@lmdb/lmdb-linux-x64@npm:2.7.11":
-  version: 2.7.11
-  resolution: "@lmdb/lmdb-linux-x64@npm:2.7.11"
+"@lmdb/lmdb-linux-x64@npm:2.8.5":
+  version: 2.8.5
+  resolution: "@lmdb/lmdb-linux-x64@npm:2.8.5"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@lmdb/lmdb-win32-x64@npm:2.7.11":
-  version: 2.7.11
-  resolution: "@lmdb/lmdb-win32-x64@npm:2.7.11"
+"@lmdb/lmdb-win32-x64@npm:2.8.5":
+  version: 2.8.5
+  resolution: "@lmdb/lmdb-win32-x64@npm:2.8.5"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2007,111 +1937,112 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/bundler-default@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/bundler-default@npm:2.9.3"
+"@parcel/bundler-default@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/bundler-default@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/graph": 2.9.3
-    "@parcel/hash": 2.9.3
-    "@parcel/plugin": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/graph": 3.1.0
+    "@parcel/plugin": 2.11.0
+    "@parcel/rust": 2.11.0
+    "@parcel/utils": 2.11.0
     nullthrows: ^1.1.1
-  checksum: 271f354e6148ab9abbbc0d7a5c22479f64d53196b1bff562a4235fa308c3dced568f1737d4ecb9ff971cdf0d8a36feee083f5491ce8e889cda5d718ed60eebe4
+  checksum: 6541cd9b82cd403f25fa3c1ee50d7cf9d27ed8f51256b1e4ead0655335128f9225c87e3118203b1b48e29f157a69dab5797065abb78fb03a409ad2765ea3a1e5
   languageName: node
   linkType: hard
 
-"@parcel/cache@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/cache@npm:2.9.3"
+"@parcel/cache@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/cache@npm:2.11.0"
   dependencies:
-    "@parcel/fs": 2.9.3
-    "@parcel/logger": 2.9.3
-    "@parcel/utils": 2.9.3
-    lmdb: 2.7.11
+    "@parcel/fs": 2.11.0
+    "@parcel/logger": 2.11.0
+    "@parcel/utils": 2.11.0
+    lmdb: 2.8.5
   peerDependencies:
-    "@parcel/core": ^2.9.3
-  checksum: 31bb356d2edd6e8aa467753256bd9a8cd158e885528f8407ba8ecf250994e86d66f103ba89c8dbb0419639c4de5e98d906d95663eabc3363a972e8eb9b2d6493
+    "@parcel/core": ^2.11.0
+  checksum: bcb6ce02244e8bbc3c23647b01a6d4907141de3fc28d5ebabc095d8d8328bfb903da02cf3d8faedd337303afe8bf139e514ed7c0228e6e64bdf628cc40e359b6
   languageName: node
   linkType: hard
 
-"@parcel/codeframe@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/codeframe@npm:2.9.3"
+"@parcel/codeframe@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/codeframe@npm:2.11.0"
   dependencies:
     chalk: ^4.1.0
-  checksum: f86a4d90eb4c33fd7c5189bf26b1d41e7955433e5a9be7fe1ce267abb74d7ad4bceeecd77db167c971604d4fef6c6fae4f5f12fa7d7f4078913ed7c92396bc14
+  checksum: abd6b7b444dadcf0a986129c782286fe77098dad584ecc91cabf0b64468b2c7150587ce5e1f548ca9943c3a12bf8fa9abddab3f193df057600bdf88b92928897
   languageName: node
   linkType: hard
 
-"@parcel/compressor-raw@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/compressor-raw@npm:2.9.3"
+"@parcel/compressor-raw@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/compressor-raw@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-  checksum: 2124c347a538b18d880ee0ae9e3e574236e402fec46b8288ccde83fcf81b51eb0d85e39067eff3ff6e8872461cbe5b39de4be5a12669efc33e08f8dd70b2b943
+    "@parcel/plugin": 2.11.0
+  checksum: 90882f3afa36c4a9f66be7379d39f144d55642398ac50b96394e91c72f2c1b1068297e12ab31f5e229645445024ded24471ee4b4ff6d754c60cf75b8f44b8c61
   languageName: node
   linkType: hard
 
-"@parcel/config-default@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/config-default@npm:2.9.3"
+"@parcel/config-default@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/config-default@npm:2.11.0"
   dependencies:
-    "@parcel/bundler-default": 2.9.3
-    "@parcel/compressor-raw": 2.9.3
-    "@parcel/namer-default": 2.9.3
-    "@parcel/optimizer-css": 2.9.3
-    "@parcel/optimizer-htmlnano": 2.9.3
-    "@parcel/optimizer-image": 2.9.3
-    "@parcel/optimizer-svgo": 2.9.3
-    "@parcel/optimizer-swc": 2.9.3
-    "@parcel/packager-css": 2.9.3
-    "@parcel/packager-html": 2.9.3
-    "@parcel/packager-js": 2.9.3
-    "@parcel/packager-raw": 2.9.3
-    "@parcel/packager-svg": 2.9.3
-    "@parcel/reporter-dev-server": 2.9.3
-    "@parcel/resolver-default": 2.9.3
-    "@parcel/runtime-browser-hmr": 2.9.3
-    "@parcel/runtime-js": 2.9.3
-    "@parcel/runtime-react-refresh": 2.9.3
-    "@parcel/runtime-service-worker": 2.9.3
-    "@parcel/transformer-babel": 2.9.3
-    "@parcel/transformer-css": 2.9.3
-    "@parcel/transformer-html": 2.9.3
-    "@parcel/transformer-image": 2.9.3
-    "@parcel/transformer-js": 2.9.3
-    "@parcel/transformer-json": 2.9.3
-    "@parcel/transformer-postcss": 2.9.3
-    "@parcel/transformer-posthtml": 2.9.3
-    "@parcel/transformer-raw": 2.9.3
-    "@parcel/transformer-react-refresh-wrap": 2.9.3
-    "@parcel/transformer-svg": 2.9.3
+    "@parcel/bundler-default": 2.11.0
+    "@parcel/compressor-raw": 2.11.0
+    "@parcel/namer-default": 2.11.0
+    "@parcel/optimizer-css": 2.11.0
+    "@parcel/optimizer-htmlnano": 2.11.0
+    "@parcel/optimizer-image": 2.11.0
+    "@parcel/optimizer-svgo": 2.11.0
+    "@parcel/optimizer-swc": 2.11.0
+    "@parcel/packager-css": 2.11.0
+    "@parcel/packager-html": 2.11.0
+    "@parcel/packager-js": 2.11.0
+    "@parcel/packager-raw": 2.11.0
+    "@parcel/packager-svg": 2.11.0
+    "@parcel/packager-wasm": 2.11.0
+    "@parcel/reporter-dev-server": 2.11.0
+    "@parcel/resolver-default": 2.11.0
+    "@parcel/runtime-browser-hmr": 2.11.0
+    "@parcel/runtime-js": 2.11.0
+    "@parcel/runtime-react-refresh": 2.11.0
+    "@parcel/runtime-service-worker": 2.11.0
+    "@parcel/transformer-babel": 2.11.0
+    "@parcel/transformer-css": 2.11.0
+    "@parcel/transformer-html": 2.11.0
+    "@parcel/transformer-image": 2.11.0
+    "@parcel/transformer-js": 2.11.0
+    "@parcel/transformer-json": 2.11.0
+    "@parcel/transformer-postcss": 2.11.0
+    "@parcel/transformer-posthtml": 2.11.0
+    "@parcel/transformer-raw": 2.11.0
+    "@parcel/transformer-react-refresh-wrap": 2.11.0
+    "@parcel/transformer-svg": 2.11.0
   peerDependencies:
-    "@parcel/core": ^2.9.3
-  checksum: 61ef21351ede9475fbe8e49fecd1bcdd6d50aa323e2f080fdc95a55428f43f0b38929f13252e227267e5ecce933166ede4c1a89c2461c605e37e25e13b7cee13
+    "@parcel/core": ^2.11.0
+  checksum: b35be2dcd3e34185d43f168ad95db6c9681b8600d4e5b08768931c845479a0b2b4b360650018073c300767416dc446e5bcf0ce311e5b31c1dfa4c0d7d536a040
   languageName: node
   linkType: hard
 
-"@parcel/core@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/core@npm:2.9.3"
+"@parcel/core@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/core@npm:2.11.0"
   dependencies:
     "@mischnic/json-sourcemap": ^0.1.0
-    "@parcel/cache": 2.9.3
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/events": 2.9.3
-    "@parcel/fs": 2.9.3
-    "@parcel/graph": 2.9.3
-    "@parcel/hash": 2.9.3
-    "@parcel/logger": 2.9.3
-    "@parcel/package-manager": 2.9.3
-    "@parcel/plugin": 2.9.3
-    "@parcel/profiler": 2.9.3
+    "@parcel/cache": 2.11.0
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/events": 2.11.0
+    "@parcel/fs": 2.11.0
+    "@parcel/graph": 3.1.0
+    "@parcel/logger": 2.11.0
+    "@parcel/package-manager": 2.11.0
+    "@parcel/plugin": 2.11.0
+    "@parcel/profiler": 2.11.0
+    "@parcel/rust": 2.11.0
     "@parcel/source-map": ^2.1.1
-    "@parcel/types": 2.9.3
-    "@parcel/utils": 2.9.3
-    "@parcel/workers": 2.9.3
+    "@parcel/types": 2.11.0
+    "@parcel/utils": 2.11.0
+    "@parcel/workers": 2.11.0
     abortcontroller-polyfill: ^1.1.9
     base-x: ^3.0.8
     browserslist: ^4.6.6
@@ -2119,369 +2050,373 @@ __metadata:
     dotenv: ^7.0.0
     dotenv-expand: ^5.1.0
     json5: ^2.2.0
-    msgpackr: ^1.5.4
+    msgpackr: ^1.9.9
     nullthrows: ^1.1.1
     semver: ^7.5.2
-  checksum: e4ba4e0909a0d2a097fbb2bdefd388ac19a29ba73e898cdaa18e9fe0ea622d853fcb1033525ab1e9bceb9f8ef544e1fe1b27a2e0228cbb319fe3285e1b59f95b
+  checksum: 22d4e1f3f5bcb7647c520fdc90bca725cc291e8b1aea71dd1eb0ecf4deb191ccc16f07a4df660ebc237e17f5fcfe35c1f8ec1eb47189c9d953ff59eb27fde344
   languageName: node
   linkType: hard
 
-"@parcel/diagnostic@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/diagnostic@npm:2.9.3"
+"@parcel/diagnostic@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/diagnostic@npm:2.11.0"
   dependencies:
     "@mischnic/json-sourcemap": ^0.1.0
     nullthrows: ^1.1.1
-  checksum: 5897500e3b86181ca5975ec4fca6a931e27e76943efe4d76b02850a35c2394ed94f6f91f94d1a00faf0be2e4a1bfc087150cea8c17d23bbcd0250a0aa12e32d8
+  checksum: bcfd74db92bb4a05eaf2abec7ade76f68b119cf3f07ab6eebc8a9b37871ef9839a7dad9476d7c114a6ce15d1fc2569de50dccd38ed28251375f0f72ad35b0349
   languageName: node
   linkType: hard
 
-"@parcel/events@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/events@npm:2.9.3"
-  checksum: c61ac95ce201183f2f0f6398e567b1fb02eba7ccb2e0ccab268b949e03095f08ab58ef82e8c547e1e816561ee9a0d9e83d0e86df2c467ff9f9f66451d84c33ee
+"@parcel/events@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/events@npm:2.11.0"
+  checksum: e757383143ad2c5b5fed800eb8fd8a0bf2d6c362dbc1f55993d0be575b5f7b7ad0fcead1db695ceb48e49fb13126849b282879097b4a14ccb8fc3fc522e9e10f
   languageName: node
   linkType: hard
 
-"@parcel/fs-search@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/fs-search@npm:2.9.3"
-  checksum: 6e7df35cc20932d20fbbbcc4bb81d346bf142359a308f2bd114a5b681776b9586adc36f88b2b7d7beae33e7b98ef8f30a30ec9f98a35e705477f2282e91efefc
-  languageName: node
-  linkType: hard
-
-"@parcel/fs@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/fs@npm:2.9.3"
+"@parcel/fs@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/fs@npm:2.11.0"
   dependencies:
-    "@parcel/fs-search": 2.9.3
-    "@parcel/types": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/rust": 2.11.0
+    "@parcel/types": 2.11.0
+    "@parcel/utils": 2.11.0
     "@parcel/watcher": ^2.0.7
-    "@parcel/workers": 2.9.3
+    "@parcel/workers": 2.11.0
   peerDependencies:
-    "@parcel/core": ^2.9.3
-  checksum: c9bf9ca9e60364fbf84362dd4a19a4c73b17ac6563e9894beafc8728a811226f67010c08018e774e8a194f1c63e5445a78be757246205427ccd34b299c18c9d2
+    "@parcel/core": ^2.11.0
+  checksum: 2702d29dd72c73b30268b1dbeba5bd8c74638baa69c96415c9fc5182cf3fa312c575f22e01f021f42043b32a877ca980e61997332301b15fc2fa626e485edd13
   languageName: node
   linkType: hard
 
-"@parcel/graph@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/graph@npm:2.9.3"
+"@parcel/graph@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@parcel/graph@npm:3.1.0"
   dependencies:
     nullthrows: ^1.1.1
-  checksum: 7fdd830928cddd56aca9427fb3ea5ad8fd2378876d71a39f4351f37b7e7bfaeef971f45c3b9c710b337e258eea300ad702446169bac3a4bbae8c283f5e1145be
+  checksum: 6d645e3ab4bb06fbc967e71072ebe796c602aacf5ac79d30e2d40442d6b08785bed49165b28a914ca419a949f4dec4dc3b2557520064c4a53bcc04f4b023daf0
   languageName: node
   linkType: hard
 
-"@parcel/hash@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/hash@npm:2.9.3"
+"@parcel/logger@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/logger@npm:2.11.0"
   dependencies:
-    xxhash-wasm: ^0.4.2
-  checksum: d5329116c55a62026da8a15a5bb8b8b4fbb2308004bd03c6755ca1e7b83a2dd9b18bd2e7c288d25cefd4f5338d128fccbaf8d3f2a9351e292e7f040b4ba80f69
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/events": 2.11.0
+  checksum: 363cacf5969df4d8b28d397f025cb9f318ebd940cd2372ffdcd25bdbeca25844b9ae7777f35dd7cdb2d1029a8c7379f6c0173bdfc201b88f4acfe6fd7f315ec5
   languageName: node
   linkType: hard
 
-"@parcel/logger@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/logger@npm:2.9.3"
-  dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/events": 2.9.3
-  checksum: eb68996b7be5a8373083b93e8f5655e4e685c1dec15840d3b724af44ecefc101b595263ec53d3f5f7870c29328e25e67065449f1e310f485f9b7bb4c29bf0ee3
-  languageName: node
-  linkType: hard
-
-"@parcel/markdown-ansi@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/markdown-ansi@npm:2.9.3"
+"@parcel/markdown-ansi@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/markdown-ansi@npm:2.11.0"
   dependencies:
     chalk: ^4.1.0
-  checksum: da1fed88dddb4529ebf489676568ca3bae7b302c96156ec0419811b23ee7056a17c308994cf80cb6952abf3f954933348af75e9fd5394b29ea291182b35cb3b4
+  checksum: 26bc69d6e227b3d461b3501014bd9c33cdb7c6514447b7eeb0f17c97ff9dc74f3bdddf271f9976e14c918516044128f477e884ce94b765c5a7e23661edfa739f
   languageName: node
   linkType: hard
 
-"@parcel/namer-default@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/namer-default@npm:2.9.3"
+"@parcel/namer-default@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/namer-default@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/plugin": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
     nullthrows: ^1.1.1
-  checksum: 23a588ee0f1460665c773986d5611219418fa1abac7e270613c52ae22f1fed0a9009a57c8ebf1e9fb0e15a000869b4c351186eac2f411c0a6c00b621377c598c
+  checksum: 452978cb597729cc21aec11456dd2121860893c9dec20f588cfc087643f127a6553493bcec5916d32285e7af11d5b832c24f07a10424cf264b4dac7ba1dfc101
   languageName: node
   linkType: hard
 
-"@parcel/node-resolver-core@npm:3.0.3":
-  version: 3.0.3
-  resolution: "@parcel/node-resolver-core@npm:3.0.3"
+"@parcel/node-resolver-core@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@parcel/node-resolver-core@npm:3.2.0"
   dependencies:
     "@mischnic/json-sourcemap": ^0.1.0
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/fs": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/fs": 2.11.0
+    "@parcel/rust": 2.11.0
+    "@parcel/utils": 2.11.0
     nullthrows: ^1.1.1
     semver: ^7.5.2
-  checksum: 871f09066f9226f56ff21da16971c8046fb86fdfb465eba6930038b9a6ca9b288f561b268007e3b812236c2ea0dd2391055cbc1aa35178b356fcdd5fc0066b03
+  checksum: 9a006b50b1af5d0c4461647d5de5932a39c910ddd8da478dba68d4c814a92cb20cfca59fde98a3def9b899126a637bb7e1445fa97e794cb57487e7c0be678858
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-css@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/optimizer-css@npm:2.9.3"
+"@parcel/optimizer-css@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/optimizer-css@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/plugin": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
     "@parcel/source-map": ^2.1.1
-    "@parcel/utils": 2.9.3
+    "@parcel/utils": 2.11.0
     browserslist: ^4.6.6
-    lightningcss: ^1.16.1
+    lightningcss: ^1.22.1
     nullthrows: ^1.1.1
-  checksum: 09cdfb81911ba474f9076a24d08074206e6ade2ffc04ded9724f09677ec60e70fb9bb87685c35717c50b465d77183cb664cd43589506c63400befdac19d96170
+  checksum: 8407b5e864a96e768a719ff35498353c5604c8b0c469f2a265d133bce05a1e80a0d95adcfc0a758c83ff35da5b3d12bf44b0b0f8598d2e2c16e86e6c527e9208
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-htmlnano@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/optimizer-htmlnano@npm:2.9.3"
+"@parcel/optimizer-htmlnano@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/optimizer-htmlnano@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
+    "@parcel/plugin": 2.11.0
     htmlnano: ^2.0.0
     nullthrows: ^1.1.1
     posthtml: ^0.16.5
     svgo: ^2.4.0
-  checksum: 32658dd81c75df9e85f348fe285d2b64805d47799f7b8574ca2bd79eebdb854385804d933818504f05d1368335e89cc22e001e739a68352967347dc6d7994228
+  checksum: 4943948a8f345b8f7024d68b7f401befe943f0de00eb826df530e67f8155739dbae386fae350ad6e7a8ec00ba41598333fa48a3e51cc364cd517e17975131f38
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-image@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/optimizer-image@npm:2.9.3"
+"@parcel/optimizer-image@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/optimizer-image@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/plugin": 2.9.3
-    "@parcel/utils": 2.9.3
-    "@parcel/workers": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
+    "@parcel/rust": 2.11.0
+    "@parcel/utils": 2.11.0
+    "@parcel/workers": 2.11.0
   peerDependencies:
-    "@parcel/core": ^2.9.3
-  checksum: 5053b2724474409407fd05d0250144cdcca65b731ce4d731cd9d77a241f4973c1f9e7edd2fce98724a6ad20070e1fed127898e7b3a41e762d81e044985619eb3
+    "@parcel/core": ^2.11.0
+  checksum: 9c4d9d087fd9bb47c150b80e2f92620ba376ca6462415a17ea0d81a0c674db363fe8364a7fc39aa1bed25c96e95742b73e18fdab1f2767c78b6e6f9c0fbbe08c
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-svgo@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/optimizer-svgo@npm:2.9.3"
+"@parcel/optimizer-svgo@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/optimizer-svgo@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/plugin": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
+    "@parcel/utils": 2.11.0
     svgo: ^2.4.0
-  checksum: fd2f1a9fc67bf44184ea00465695bae50b604f506f60b6f02c607267fd108cc4776d6069412550e0d4133d7d5e91ed91d9b84658c3d2d488d5854f4a93d84e72
+  checksum: 4e671856c28435e4f19335fa5ed062878a9d6fe4232ff22befab5a90df360db1904afbd55bfd4ecff193f4bcd7a9081f5d23db54bb644bb7160fcfa1aac4facf
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-swc@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/optimizer-swc@npm:2.9.3"
+"@parcel/optimizer-swc@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/optimizer-swc@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/plugin": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
     "@parcel/source-map": ^2.1.1
-    "@parcel/utils": 2.9.3
+    "@parcel/utils": 2.11.0
     "@swc/core": ^1.3.36
     nullthrows: ^1.1.1
-  checksum: 087012a418442d13da1a3f0e4452259762e76568153f1a926dd9371e52d54110c2ca68b2e57861be16032a7b5406c7afd90867d50b8a91c402ab8c2afd8a6c49
+  checksum: be4b8bc94a5a490f6912a6dee24473eced904f2122f684d164cd781e7b216375999c5a15efa91fece4cb50cfc0c4eaabe9a8773df263163b5951e9d4e76a5798
   languageName: node
   linkType: hard
 
-"@parcel/package-manager@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/package-manager@npm:2.9.3"
+"@parcel/package-manager@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/package-manager@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/fs": 2.9.3
-    "@parcel/logger": 2.9.3
-    "@parcel/node-resolver-core": 3.0.3
-    "@parcel/types": 2.9.3
-    "@parcel/utils": 2.9.3
-    "@parcel/workers": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/fs": 2.11.0
+    "@parcel/logger": 2.11.0
+    "@parcel/node-resolver-core": 3.2.0
+    "@parcel/types": 2.11.0
+    "@parcel/utils": 2.11.0
+    "@parcel/workers": 2.11.0
     semver: ^7.5.2
   peerDependencies:
-    "@parcel/core": ^2.9.3
-  checksum: 46acc905b86fa97799096053abdbd384a9b439623064e541c1848ce52923e9f15e5cebaae9ef970872262e5710741836a8644d39155b0d84f15fbbd03089c9d9
+    "@parcel/core": ^2.11.0
+  checksum: 3846542eb59ee39ad53c1aea56f59045a26e58d07b0f0f59a91ca1b91e1268e76cd564a914e1041120f870481ae46063a39737e67d2418547cc0ff0dcf08a124
   languageName: node
   linkType: hard
 
-"@parcel/packager-css@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/packager-css@npm:2.9.3"
+"@parcel/packager-css@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/packager-css@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/plugin": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
     "@parcel/source-map": ^2.1.1
-    "@parcel/utils": 2.9.3
+    "@parcel/utils": 2.11.0
     nullthrows: ^1.1.1
-  checksum: 725245c5d627966a6e7f520f8def814a7751438bb36f7df93d61462b461829b54a886bedeb5b509e00c94152768b06b1205be04d9701fc5c977e2a081e20452d
+  checksum: 2aa8da12ca83353153cb4d70893dfa691bab6f9e884b434812f3d4200fec3d2bd5a89df1a4c6c9a0d0955b5b5ef88bfacb4287f87c066f377fc304ef5a099720
   languageName: node
   linkType: hard
 
-"@parcel/packager-html@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/packager-html@npm:2.9.3"
+"@parcel/packager-html@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/packager-html@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-    "@parcel/types": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/plugin": 2.11.0
+    "@parcel/types": 2.11.0
+    "@parcel/utils": 2.11.0
     nullthrows: ^1.1.1
     posthtml: ^0.16.5
-  checksum: 163217c86a8ecde8696a2750f8cb51dee028cf5491a49808addb19ee2db1d68b897fde8f887800b0f47a699f61842cb0959119d0dc8f750462623bd2ad608802
+  checksum: a651b4f3cf1e398ff111f31519610957863701471a763369fa26fa7398ed96c02a41f76575e60262e091506f7e7b4c7d3c7df9b3a12fb04dc62e7c9fe0604d71
   languageName: node
   linkType: hard
 
-"@parcel/packager-js@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/packager-js@npm:2.9.3"
+"@parcel/packager-js@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/packager-js@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/hash": 2.9.3
-    "@parcel/plugin": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
+    "@parcel/rust": 2.11.0
     "@parcel/source-map": ^2.1.1
-    "@parcel/utils": 2.9.3
+    "@parcel/types": 2.11.0
+    "@parcel/utils": 2.11.0
     globals: ^13.2.0
     nullthrows: ^1.1.1
-  checksum: db8c74ec80921ea5c6fee9496f007b9f68cfd165710143137c07eaa16873ca976eb0065ffab8e4f9627946d6664141835089ec731ab10b8ee1e3aa53bdbb93b6
+  checksum: 63d96fb22be90f54f5562fc93baad13deff63d7e434648f606b455800610679231a8e7b1349bd0f212568e2e4cf519c6368fbda8f1b0ae392870ecfa6bf8265f
   languageName: node
   linkType: hard
 
-"@parcel/packager-raw@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/packager-raw@npm:2.9.3"
+"@parcel/packager-raw@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/packager-raw@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-  checksum: 840ddac49ce8c22cb815a1738cb8a40b9b1c6ccdf5a046b414a5f76fc08a5c870248eb76dbe61c4c06956d1b1c016dc7a49a1383176ae0a2f9cca4c1be9fced7
+    "@parcel/plugin": 2.11.0
+  checksum: c36dbcc82a31643fd83dce8a5dc5bb038a9396ffec46a8f9c8a7ad35f4645d2050c4228ed360f2c70f11073a606b6c89872a70883d07594b91bd8ce9191ed3a2
   languageName: node
   linkType: hard
 
-"@parcel/packager-svg@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/packager-svg@npm:2.9.3"
+"@parcel/packager-svg@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/packager-svg@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-    "@parcel/types": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/plugin": 2.11.0
+    "@parcel/types": 2.11.0
+    "@parcel/utils": 2.11.0
     posthtml: ^0.16.4
-  checksum: ff09cfdbc523822c47e62e00e820b3d476ff9c30fc97b3c33d7d7d6e0926cf0e630106fdc3b079640a46c4af91bf733599c9d66e45943e4a3ecbfa2890e8d33d
+  checksum: 2d0394dd5e9ce0025f805241975ee26318f176b42ca30d6f020cfb5521f77ca6eb2b13c9c23f580bab69e55ca883f06d6c023faa3b84e15f2e7d6e826ed2f961
   languageName: node
   linkType: hard
 
-"@parcel/plugin@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/plugin@npm:2.9.3"
+"@parcel/packager-wasm@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/packager-wasm@npm:2.11.0"
   dependencies:
-    "@parcel/types": 2.9.3
-  checksum: e9d775a4fdf4635940f900eb8dc8f2ef7f6ff087d48ce876cfac567e4070120614a8c8990146732c1d1c2c483d211f00db3ded8dd0610276c997bb2a7a3ba3a5
+    "@parcel/plugin": 2.11.0
+  checksum: 4f0617fe512ffdce0157dff47311ef241645482ddd8a90614bab658de7c1b51387eede6e841480c4478557934e2ce1d318d970f45a8048edfbf8992da7c2bc18
   languageName: node
   linkType: hard
 
-"@parcel/profiler@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/profiler@npm:2.9.3"
+"@parcel/plugin@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/plugin@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/events": 2.9.3
+    "@parcel/types": 2.11.0
+  checksum: 45344c3ac0674b77ea29cbac23de5887fac68bfba118adf93c9bab4631c1e341e1212d250d1279581c51ad6124b6f023bbb5c2ca0e7c1afed4442fc0a0398a97
+  languageName: node
+  linkType: hard
+
+"@parcel/profiler@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/profiler@npm:2.11.0"
+  dependencies:
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/events": 2.11.0
     chrome-trace-event: ^1.0.2
-  checksum: 30e988b99ed7d58ae0bba61cd92f214e73d37e611699796f55f2c22a60f0d24a4be1642b38c7ee71440a408bf7a240e3ff2bf5737d1a243778ff695794ccfcee
+  checksum: f5b5749786de62f1d9d0285adbbe49e170e691fdbf789d9d706c84b72ed6a300978f2144f7c56f4695fff6ee4388df97158554b105631adde6e43d3ee0090784
   languageName: node
   linkType: hard
 
-"@parcel/reporter-cli@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/reporter-cli@npm:2.9.3"
+"@parcel/reporter-cli@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/reporter-cli@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-    "@parcel/types": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/plugin": 2.11.0
+    "@parcel/types": 2.11.0
+    "@parcel/utils": 2.11.0
     chalk: ^4.1.0
+    cli-progress: ^3.12.0
     term-size: ^2.2.1
-  checksum: f274aa295950cd9f61339b1eaa3265f845570de78585e5343c619cb5bc2b4ba4f37091eb0e726634c19c34366cecbba8779b4e4831596501fd69618ddcbbd4b1
+  checksum: 81e62144ad834791656458eeea286a061f4b8fa4651d8c68e54ab8050f9101ee9cfc9117f18544baebea5d47da9f4b2e3e6eabc19e7c886131bdcd9b2f40dd71
   languageName: node
   linkType: hard
 
-"@parcel/reporter-dev-server@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/reporter-dev-server@npm:2.9.3"
+"@parcel/reporter-dev-server@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/reporter-dev-server@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-    "@parcel/utils": 2.9.3
-  checksum: e8beff5f9415f5f27c1c7f2a4dfaa3e5d53712d00e3df417fc6a0163f0a2a179cc19b4decf4a236d75e251bbdc46e3b216f6fae0826e70bcf459a289c732ec9c
+    "@parcel/plugin": 2.11.0
+    "@parcel/utils": 2.11.0
+  checksum: ac8948c7f30a88c8d05d3a168381d906e6b6bfbdf04001ec46a57b0f9901f009d111ca7d200e5079ca34ce23b7754be38902492ffacdd42d544cbe26c7c2dc67
   languageName: node
   linkType: hard
 
-"@parcel/reporter-tracer@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/reporter-tracer@npm:2.9.3"
+"@parcel/reporter-tracer@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/reporter-tracer@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/plugin": 2.11.0
+    "@parcel/utils": 2.11.0
     chrome-trace-event: ^1.0.3
     nullthrows: ^1.1.1
-  checksum: 7922b1976062d078c71afa2bb216dc1afe7341d61b98b4773a02ebfb26bc63877a6674dd8a331886584e86b27839d3c9f4569747f96b0f04f9d3543ea2fc9601
+  checksum: 83aedfc97d3b79f5aae205c88267fe6baf59ccee211aca251198c55594760e84145a3e070ce5efcbef648b72c752649283f13b5500fb848f83dbf723dff295df
   languageName: node
   linkType: hard
 
-"@parcel/resolver-default@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/resolver-default@npm:2.9.3"
+"@parcel/resolver-default@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/resolver-default@npm:2.11.0"
   dependencies:
-    "@parcel/node-resolver-core": 3.0.3
-    "@parcel/plugin": 2.9.3
-  checksum: 9e14d5b9bc7333bf22bfc445b2659ef5337f7af2cc63ccefb2496b8a0989df2b021233cf8d5fe5d4f08a48b2a494ce997acddf951bbd6ffbec7336a015ee05da
+    "@parcel/node-resolver-core": 3.2.0
+    "@parcel/plugin": 2.11.0
+  checksum: bbb5f6dfd67c754680dade42005a6ddc5fc5d40f7277ba1d63df898ac117ad98c2d74b599b2df91c7f2f8503bf6ba3cb10eef9d9b4d9c09ef0e8a7eb98d38d6e
   languageName: node
   linkType: hard
 
-"@parcel/runtime-browser-hmr@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/runtime-browser-hmr@npm:2.9.3"
+"@parcel/runtime-browser-hmr@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/runtime-browser-hmr@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-    "@parcel/utils": 2.9.3
-  checksum: e79e827598e63ef083e8dbbed0e731ea202dfcc9f15c4063cbc2a81bad6c0d6981a49e8adea9326978e6d27ba6d4861507e49a062f726b846471dba4abeb0ed5
+    "@parcel/plugin": 2.11.0
+    "@parcel/utils": 2.11.0
+  checksum: ad7eba3210227ebbcb71889cdfb495172ae0173b75e140b41fe772df90c115f1bab5c23fd6209eabe94f143942725f6b3a8d497483e376cf449078c0a984bf1c
   languageName: node
   linkType: hard
 
-"@parcel/runtime-js@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/runtime-js@npm:2.9.3"
+"@parcel/runtime-js@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/runtime-js@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/plugin": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
+    "@parcel/utils": 2.11.0
     nullthrows: ^1.1.1
-  checksum: 143c3a9d9b5d37b4db9b7c169273a31f36db945a2264a448f3a90e1ee056ee28dfca325c472121a0f2425f463aac44d7ec7b7229c78f27cf1e642065b965f64f
+  checksum: 3cab5e6b6218b91b9022c9e0990674be46abd763dd4f5deaaa4d1143df22a37f479d2a1f41f9b1be35e1381437c3ed301b03afec62bb8cba613e473ffd22d43c
   languageName: node
   linkType: hard
 
-"@parcel/runtime-react-refresh@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/runtime-react-refresh@npm:2.9.3"
+"@parcel/runtime-react-refresh@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/runtime-react-refresh@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/plugin": 2.11.0
+    "@parcel/utils": 2.11.0
     react-error-overlay: 6.0.9
     react-refresh: ^0.9.0
-  checksum: 8fb9f8165e7e7c29e8b954d71d358197e4a81182856817e92da6a4ec4db3236fd6dc0d3f3cd18da344ee025a4d6ae8bd1f21495fa42b969f3ca2fdd7e4dcbd18
+  checksum: 0a29d9e55ad296ae13413e13ecea2e5966edc4e26a542bf817cc72cd15f793930abe7b2e80065e39ee647be13e211951146c8c643184da8fa2af872f09e9ffc5
   languageName: node
   linkType: hard
 
-"@parcel/runtime-service-worker@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/runtime-service-worker@npm:2.9.3"
+"@parcel/runtime-service-worker@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/runtime-service-worker@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/plugin": 2.11.0
+    "@parcel/utils": 2.11.0
     nullthrows: ^1.1.1
-  checksum: e296a42e3e20a3a7b911236e8b349182210a8603c9b4a21023308b28a628c43acb23518e2b0502ef11e33463fa0426b344260a835e87f9a24838d5572df162ef
+  checksum: da8d2b5a925f710e14f9dd49d968603946961b4f8d1f4ef8d4b68e350118d2f6ae42115adcc6952ebe01151dd185de827902d3984367c20c5f9381890d8bfeb5
+  languageName: node
+  linkType: hard
+
+"@parcel/rust@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/rust@npm:2.11.0"
+  checksum: 53a95b23562d71597af726647923db08185ede5b83fd25f00467229b62a51fd5b43a0e44172d90d68721e1463fb4c5f06000ddd47d402779177fe7c441fe8b16
   languageName: node
   linkType: hard
 
@@ -2494,193 +2429,194 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/transformer-babel@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/transformer-babel@npm:2.9.3"
+"@parcel/transformer-babel@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/transformer-babel@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/plugin": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
     "@parcel/source-map": ^2.1.1
-    "@parcel/utils": 2.9.3
+    "@parcel/utils": 2.11.0
     browserslist: ^4.6.6
     json5: ^2.2.0
     nullthrows: ^1.1.1
     semver: ^7.5.2
-  checksum: 4d0246290ec37409a1c1db424b5e2daa974bd8fbec65560f1f5614d12db2956b386fd38539e45544b1be1098fadee8f0e971f5738da897cedda84f608c40a226
+  checksum: f36c7973c691619b4c35bdd40135cd6daf735b333f34df99b6cad1b0ad332010b195bdb0388a6ff8b6abad201020a77ad797b974774bb0d26894d1c435f30814
   languageName: node
   linkType: hard
 
-"@parcel/transformer-css@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/transformer-css@npm:2.9.3"
+"@parcel/transformer-css@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/transformer-css@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/plugin": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
     "@parcel/source-map": ^2.1.1
-    "@parcel/utils": 2.9.3
+    "@parcel/utils": 2.11.0
     browserslist: ^4.6.6
-    lightningcss: ^1.16.1
+    lightningcss: ^1.22.1
     nullthrows: ^1.1.1
-  checksum: aad8e3243916cc3b7ed9e87910d43437eaced4665914d939b6ebf8ba323c7091fa3bfd532b23f50cbe2daf874c936ac6c946ea6be0dacda18cf2d733109e26f6
+  checksum: 59b1893b94388b4e7e94121cd82cbf734499e1565503b91ec0ea837d9967190c953323a4c054d8d80fd5c53f5b75710a5f20f54d129a076257497a269316a280
   languageName: node
   linkType: hard
 
-"@parcel/transformer-html@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/transformer-html@npm:2.9.3"
+"@parcel/transformer-html@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/transformer-html@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/hash": 2.9.3
-    "@parcel/plugin": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
+    "@parcel/rust": 2.11.0
     nullthrows: ^1.1.1
     posthtml: ^0.16.5
     posthtml-parser: ^0.10.1
     posthtml-render: ^3.0.0
     semver: ^7.5.2
     srcset: 4
-  checksum: 77f150b5688fe2b32abeb7e6e4fc05a97816d872b3638e5cd4fec50144f4659c2128e9a60e5e6d2cf8237028abb57f29ae279ade05e3b353cf107a89ae29a307
+  checksum: fd333e9a4890bb565b0403f065a46c9c38174b379f6fc30b557455fad13d9b13864bf2cb971ff396cea8724c74c652336f727e2df260e2bfb6d2ea7d952371ae
   languageName: node
   linkType: hard
 
-"@parcel/transformer-image@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/transformer-image@npm:2.9.3"
+"@parcel/transformer-image@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/transformer-image@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-    "@parcel/utils": 2.9.3
-    "@parcel/workers": 2.9.3
+    "@parcel/plugin": 2.11.0
+    "@parcel/utils": 2.11.0
+    "@parcel/workers": 2.11.0
     nullthrows: ^1.1.1
   peerDependencies:
-    "@parcel/core": ^2.9.3
-  checksum: 554ff7c6c2948059726ee0836a0de93d86e6f2f7d7f8454ecd6b6d7c0cd4a4c92bfe9ab668e45cd0e60118edf9e32b8c3ff5cff2fa8efb87d2db6e94633b744f
+    "@parcel/core": ^2.11.0
+  checksum: 65e7fa4791100b5db6dd6752a0f43c2c377e2f3825c5cfeb8bff5d3ae994e3ac659ebcb656a607834f54eb3cf6cf499ed78fdba64a968428c2bbcdb23b030d19
   languageName: node
   linkType: hard
 
-"@parcel/transformer-js@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/transformer-js@npm:2.9.3"
+"@parcel/transformer-js@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/transformer-js@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/plugin": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
+    "@parcel/rust": 2.11.0
     "@parcel/source-map": ^2.1.1
-    "@parcel/utils": 2.9.3
-    "@parcel/workers": 2.9.3
+    "@parcel/utils": 2.11.0
+    "@parcel/workers": 2.11.0
     "@swc/helpers": ^0.5.0
     browserslist: ^4.6.6
     nullthrows: ^1.1.1
     regenerator-runtime: ^0.13.7
     semver: ^7.5.2
   peerDependencies:
-    "@parcel/core": ^2.9.3
-  checksum: c262307651857c8434ef33612af0056c83c26874f0bcd8dae9e71e4806239d7a0bcebd8076acb4777b63ecb03104b15b98322f1f5d7214cbecbcd553cd7d82b3
+    "@parcel/core": ^2.11.0
+  checksum: ae75820a392f9728ecd4fe98a9ec746c380fb2fd927845980d0f95b0e89afe8c9bf557ba66006612811bc362caa07cd4697dfa732df8cf0de711e8666f0c80ee
   languageName: node
   linkType: hard
 
-"@parcel/transformer-json@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/transformer-json@npm:2.9.3"
+"@parcel/transformer-json@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/transformer-json@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
+    "@parcel/plugin": 2.11.0
     json5: ^2.2.0
-  checksum: 96e2157cfdde7bcdb83fd1e7718cfb439af53493a60640dfcc5820d78e13cb7c438911c360b5901240ecf51101f164706b4e0058bdf9d6108aa32fe09370a539
+  checksum: 6e25561d09ea238e96558a76c0812c423ca44633824b3271fb3bc5b77604aefe8943332f2b7b17ff7a296cc6b770a6ba3d2322eeac4650785c2f091314c71ddf
   languageName: node
   linkType: hard
 
-"@parcel/transformer-postcss@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/transformer-postcss@npm:2.9.3"
+"@parcel/transformer-postcss@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/transformer-postcss@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/hash": 2.9.3
-    "@parcel/plugin": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
+    "@parcel/rust": 2.11.0
+    "@parcel/utils": 2.11.0
     clone: ^2.1.1
     nullthrows: ^1.1.1
     postcss-value-parser: ^4.2.0
     semver: ^7.5.2
-  checksum: c396c25c5a58a1aed0e7381ee3834b5e0423baedf5dd79984b9d1540c8d693d703b4dfabde7bc1152271d783016b8552c9c442eb59152bf5071d355606a961d2
+  checksum: 10f0054e5b751275fc1571d32d91f4412b31575d45eb576d1483771c3d3c445bd50da7937a8aa6b0aa134212e2f3b608482a6e617e6472f77694cd52ec413c82
   languageName: node
   linkType: hard
 
-"@parcel/transformer-posthtml@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/transformer-posthtml@npm:2.9.3"
+"@parcel/transformer-posthtml@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/transformer-posthtml@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/plugin": 2.11.0
+    "@parcel/utils": 2.11.0
     nullthrows: ^1.1.1
     posthtml: ^0.16.5
     posthtml-parser: ^0.10.1
     posthtml-render: ^3.0.0
     semver: ^7.5.2
-  checksum: 58d4836900af9949832f69a78349fc29188aa6f54301afe392130e1d2127183691d16b6eef8adcc0d9924e47c6bc7e993c6e1dc7a507dadcb2a115fa50757c82
+  checksum: d79e3666cae4ffb648d042b30e974d68193c05ffb6418d0c79fe784e07b323fe65a3006130f63eeafe0700a09300d8c9e6dcf6a56e24ac2a23fdd30d3bd4a9b5
   languageName: node
   linkType: hard
 
-"@parcel/transformer-raw@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/transformer-raw@npm:2.9.3"
+"@parcel/transformer-raw@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/transformer-raw@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-  checksum: b639e2f5fde4066124e58c343b56cd6eeb7820cb6dd1c4feeba5b40b1f3cc222c075d61de9dd8f381dbcbb42b44bdc7bf33c0fb4edbd3da59c4e3c66e4748d4b
+    "@parcel/plugin": 2.11.0
+  checksum: b914665c090316d677fedc1b646b87c31eea277fb26281b737874940fe1c63bdbcf0f31dc4d2a4d5493bf4e61b420e7b4827039bd8409aaed8e8da4a5a03bacc
   languageName: node
   linkType: hard
 
-"@parcel/transformer-react-refresh-wrap@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/transformer-react-refresh-wrap@npm:2.9.3"
+"@parcel/transformer-react-refresh-wrap@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/transformer-react-refresh-wrap@npm:2.11.0"
   dependencies:
-    "@parcel/plugin": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/plugin": 2.11.0
+    "@parcel/utils": 2.11.0
     react-refresh: ^0.9.0
-  checksum: aede3d82af714c311e504bc2333e11b5dc29bedca580052e2fa44eca3c1e05f630352e83be30e66aaa231323f1b5b7f49011f43ff77613986519a055470649e1
+  checksum: b17b7a151da31f6abe7e33d798205af3926135e5e936025f74883285519a9fff5207c89fd06c21635965e9d8e46d62450915623d1b5bd97d50297a6633703519
   languageName: node
   linkType: hard
 
-"@parcel/transformer-svg@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/transformer-svg@npm:2.9.3"
+"@parcel/transformer-svg@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/transformer-svg@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/hash": 2.9.3
-    "@parcel/plugin": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/plugin": 2.11.0
+    "@parcel/rust": 2.11.0
     nullthrows: ^1.1.1
     posthtml: ^0.16.5
     posthtml-parser: ^0.10.1
     posthtml-render: ^3.0.0
     semver: ^7.5.2
-  checksum: 19cec37f9cfb4a5506e48e41d70e970584cd06a913dfc92d128031991ff6615ce3302a896c2766fa64be8c8f56f81da47ece05e7b65c30f7e5213e676cae346c
+  checksum: 48bf4503ded4328394fcb23ab08856a2b81fda4ec3e7755ec97492511324d66b20ed1f47e0588f011b0319795094e98537683634318eaf53fcd89229f7e9088c
   languageName: node
   linkType: hard
 
-"@parcel/types@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/types@npm:2.9.3"
+"@parcel/types@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/types@npm:2.11.0"
   dependencies:
-    "@parcel/cache": 2.9.3
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/fs": 2.9.3
-    "@parcel/package-manager": 2.9.3
+    "@parcel/cache": 2.11.0
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/fs": 2.11.0
+    "@parcel/package-manager": 2.11.0
     "@parcel/source-map": ^2.1.1
-    "@parcel/workers": 2.9.3
+    "@parcel/workers": 2.11.0
     utility-types: ^3.10.0
-  checksum: 2a2162277245d2d906a2170d8d20262247e4cb14d8c9504e86ff15e4015cbf747304d098f3211b7705ea8c5b55b47cd3594b5802e615d10d89d09e085435bc6b
+  checksum: 8534156cafcd8eeee008f7cdbe91a609c8e3c9d1fe9248c3649e0649379c3c5cd141a038ca06f457e6b46d254f2667fd55d1b89a3cf3f6091ea5102422c8fc41
   languageName: node
   linkType: hard
 
-"@parcel/utils@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/utils@npm:2.9.3"
+"@parcel/utils@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/utils@npm:2.11.0"
   dependencies:
-    "@parcel/codeframe": 2.9.3
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/hash": 2.9.3
-    "@parcel/logger": 2.9.3
-    "@parcel/markdown-ansi": 2.9.3
+    "@parcel/codeframe": 2.11.0
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/logger": 2.11.0
+    "@parcel/markdown-ansi": 2.11.0
+    "@parcel/rust": 2.11.0
     "@parcel/source-map": ^2.1.1
     chalk: ^4.1.0
     nullthrows: ^1.1.1
-  checksum: 4c1df52754bc56bc3349262bd6cf3f38cf239f27593f7d1aea987588af0a4ec13ce367f4b3026c44791071ce760071554f24cafdb3ff341f0175acd49558ac21
+  checksum: e40f4bca049881c9c4b287f0425b197f44e87a958f528e8598304b61bf645ec648ee68b4e7f194de9a3341cdd6857f3fedce71dc8ca7327d8d37017e350f42b7
   languageName: node
   linkType: hard
 
@@ -2798,19 +2734,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/workers@npm:2.9.3":
-  version: 2.9.3
-  resolution: "@parcel/workers@npm:2.9.3"
+"@parcel/workers@npm:2.11.0":
+  version: 2.11.0
+  resolution: "@parcel/workers@npm:2.11.0"
   dependencies:
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/logger": 2.9.3
-    "@parcel/profiler": 2.9.3
-    "@parcel/types": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/logger": 2.11.0
+    "@parcel/profiler": 2.11.0
+    "@parcel/types": 2.11.0
+    "@parcel/utils": 2.11.0
     nullthrows: ^1.1.1
   peerDependencies:
-    "@parcel/core": ^2.9.3
-  checksum: d6ac6e2abf1b38aefeef26f687e0091e191f6b1969728abe44c4cda988d070759db3352784c287b6a10ed6694feb05c12a9510ea756b3edbb0367eaa8cfc81a7
+    "@parcel/core": ^2.11.0
+  checksum: 0771ad5372a4d27e64d6009df1a81a8a302031dcef041ddd11b43089262af3c4e6c62c0beb05485eddb2a61fc6993eb8ed04379de60cb61988d5195b352e88cc
   languageName: node
   linkType: hard
 
@@ -4496,6 +4432,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-progress@npm:^3.12.0":
+  version: 3.12.0
+  resolution: "cli-progress@npm:3.12.0"
+  dependencies:
+    string-width: ^4.2.3
+  checksum: e8390dc3cdf3c72ecfda0a1e8997bfed63a0d837f97366bbce0ca2ff1b452da386caed007b389f0fe972625037b6c8e7ab087c69d6184cc4dfc8595c4c1d3e6e
+  languageName: node
+  linkType: hard
+
 "cliui@npm:^8.0.1":
   version: 8.0.1
   resolution: "cliui@npm:8.0.1"
@@ -5081,6 +5026,13 @@ __metadata:
   bin:
     detect-libc: ./bin/detect-libc.js
   checksum: daaaed925ffa7889bd91d56e9624e6c8033911bb60f3a50a74a87500680652969dbaab9526d1e200a4c94acf80fc862a22131841145a0a8482d60a99c24f4a3e
+  languageName: node
+  linkType: hard
+
+"detect-libc@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "detect-libc@npm:2.0.2"
+  checksum: 2b2cd3649b83d576f4be7cc37eb3b1815c79969c8b1a03a40a4d55d83bc74d010753485753448eacb98784abf22f7dbd3911fd3b60e29fda28fed2d1a997944d
   languageName: node
   linkType: hard
 
@@ -6787,79 +6739,89 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss-darwin-arm64@npm:1.19.0":
-  version: 1.19.0
-  resolution: "lightningcss-darwin-arm64@npm:1.19.0"
+"lightningcss-darwin-arm64@npm:1.24.0":
+  version: 1.24.0
+  resolution: "lightningcss-darwin-arm64@npm:1.24.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"lightningcss-darwin-x64@npm:1.19.0":
-  version: 1.19.0
-  resolution: "lightningcss-darwin-x64@npm:1.19.0"
+"lightningcss-darwin-x64@npm:1.24.0":
+  version: 1.24.0
+  resolution: "lightningcss-darwin-x64@npm:1.24.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"lightningcss-linux-arm-gnueabihf@npm:1.19.0":
-  version: 1.19.0
-  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.19.0"
+"lightningcss-freebsd-x64@npm:1.24.0":
+  version: 1.24.0
+  resolution: "lightningcss-freebsd-x64@npm:1.24.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm-gnueabihf@npm:1.24.0":
+  version: 1.24.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.24.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"lightningcss-linux-arm64-gnu@npm:1.19.0":
-  version: 1.19.0
-  resolution: "lightningcss-linux-arm64-gnu@npm:1.19.0"
+"lightningcss-linux-arm64-gnu@npm:1.24.0":
+  version: 1.24.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.24.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"lightningcss-linux-arm64-musl@npm:1.19.0":
-  version: 1.19.0
-  resolution: "lightningcss-linux-arm64-musl@npm:1.19.0"
+"lightningcss-linux-arm64-musl@npm:1.24.0":
+  version: 1.24.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.24.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"lightningcss-linux-x64-gnu@npm:1.19.0":
-  version: 1.19.0
-  resolution: "lightningcss-linux-x64-gnu@npm:1.19.0"
+"lightningcss-linux-x64-gnu@npm:1.24.0":
+  version: 1.24.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.24.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"lightningcss-linux-x64-musl@npm:1.19.0":
-  version: 1.19.0
-  resolution: "lightningcss-linux-x64-musl@npm:1.19.0"
+"lightningcss-linux-x64-musl@npm:1.24.0":
+  version: 1.24.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.24.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"lightningcss-win32-x64-msvc@npm:1.19.0":
-  version: 1.19.0
-  resolution: "lightningcss-win32-x64-msvc@npm:1.19.0"
+"lightningcss-win32-x64-msvc@npm:1.24.0":
+  version: 1.24.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.24.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"lightningcss@npm:^1.16.1":
-  version: 1.19.0
-  resolution: "lightningcss@npm:1.19.0"
+"lightningcss@npm:^1.22.1":
+  version: 1.24.0
+  resolution: "lightningcss@npm:1.24.0"
   dependencies:
     detect-libc: ^1.0.3
-    lightningcss-darwin-arm64: 1.19.0
-    lightningcss-darwin-x64: 1.19.0
-    lightningcss-linux-arm-gnueabihf: 1.19.0
-    lightningcss-linux-arm64-gnu: 1.19.0
-    lightningcss-linux-arm64-musl: 1.19.0
-    lightningcss-linux-x64-gnu: 1.19.0
-    lightningcss-linux-x64-musl: 1.19.0
-    lightningcss-win32-x64-msvc: 1.19.0
+    lightningcss-darwin-arm64: 1.24.0
+    lightningcss-darwin-x64: 1.24.0
+    lightningcss-freebsd-x64: 1.24.0
+    lightningcss-linux-arm-gnueabihf: 1.24.0
+    lightningcss-linux-arm64-gnu: 1.24.0
+    lightningcss-linux-arm64-musl: 1.24.0
+    lightningcss-linux-x64-gnu: 1.24.0
+    lightningcss-linux-x64-musl: 1.24.0
+    lightningcss-win32-x64-msvc: 1.24.0
   dependenciesMeta:
     lightningcss-darwin-arm64:
       optional: true
     lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
       optional: true
     lightningcss-linux-arm-gnueabihf:
       optional: true
@@ -6873,7 +6835,7 @@ __metadata:
       optional: true
     lightningcss-win32-x64-msvc:
       optional: true
-  checksum: c51de34b7379f9da391d0c1157893bb1484357d1ce2212a8c7943690d7a4fed7f2fa0d2dd7a92004b4444662011564ec7bf31f458a1638c856c529fe07285177
+  checksum: ac3e5d723182ee8e6d6e62f223690d22e7af00d1532b2183a5a3872a19e81e5594014aeed426efef631966f1f96f736948481d45916e48256b88d2eda77e4a0d
   languageName: node
   linkType: hard
 
@@ -6884,21 +6846,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lmdb@npm:2.7.11":
-  version: 2.7.11
-  resolution: "lmdb@npm:2.7.11"
+"lmdb@npm:2.8.5":
+  version: 2.8.5
+  resolution: "lmdb@npm:2.8.5"
   dependencies:
-    "@lmdb/lmdb-darwin-arm64": 2.7.11
-    "@lmdb/lmdb-darwin-x64": 2.7.11
-    "@lmdb/lmdb-linux-arm": 2.7.11
-    "@lmdb/lmdb-linux-arm64": 2.7.11
-    "@lmdb/lmdb-linux-x64": 2.7.11
-    "@lmdb/lmdb-win32-x64": 2.7.11
-    msgpackr: 1.8.5
-    node-addon-api: ^4.3.0
+    "@lmdb/lmdb-darwin-arm64": 2.8.5
+    "@lmdb/lmdb-darwin-x64": 2.8.5
+    "@lmdb/lmdb-linux-arm": 2.8.5
+    "@lmdb/lmdb-linux-arm64": 2.8.5
+    "@lmdb/lmdb-linux-x64": 2.8.5
+    "@lmdb/lmdb-win32-x64": 2.8.5
+    msgpackr: ^1.9.5
+    node-addon-api: ^6.1.0
     node-gyp: latest
-    node-gyp-build-optional-packages: 5.0.6
-    ordered-binary: ^1.4.0
+    node-gyp-build-optional-packages: 5.1.1
+    ordered-binary: ^1.4.1
     weak-lru-cache: ^1.2.2
   dependenciesMeta:
     "@lmdb/lmdb-darwin-arm64":
@@ -6915,7 +6877,7 @@ __metadata:
       optional: true
   bin:
     download-lmdb-prebuilds: bin/download-prebuilds.js
-  checksum: 44f9c7ea078b79c5a11179af3e4a6e604c63ced6fedbd58b06a048ba9e1ab54bac5772675a7de637a7955918ea7fa62c233d76d0a232137b3003ede539cd8516
+  checksum: b1ec76650d3b19d4c966cd7a4ee2324270c7d20f46b569d23bc287c7c7e7da667d3d330aa78be1aa2717af63b3531cd1d53a5ee4faf1c293c038513e4f3aa832
   languageName: node
   linkType: hard
 
@@ -7343,17 +7305,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"monaco-editor@npm:^0.46.0, monaco-editor@npm:~0.46.0":
+"monaco-editor@npm:0.46.0":
   version: 0.46.0
   resolution: "monaco-editor@npm:0.46.0"
   checksum: be7aaa2747b8d3a3537f56c9353ebe779b188eb1480f6453fa1e346d8ccdd27068cb4508c8f6f3b8cc07ac0f792a3d6df36168d54cd6e074742182525115be86
   languageName: node
   linkType: hard
 
-"monaco-editor@npm:~0.45.0":
-  version: 0.45.0
-  resolution: "monaco-editor@npm:0.45.0"
-  checksum: 7c70aeea8b81bc8dbda4b962fa8236d41fd2a3d07bcc2843ea7f1756ad95d701da5ef71e67d787595567aeec247ceb6bf4e3451abdf4895fe7819a8b9ef76231
+"monaco-editor@patch:monaco-editor@npm%3A0.46.0#./.yarn/patches/monaco-editor-npm-0.46.0-fb69b10c11.patch::locator=monaco-kusto%40workspace%3A.":
+  version: 0.46.0
+  resolution: "monaco-editor@patch:monaco-editor@npm%3A0.46.0#./.yarn/patches/monaco-editor-npm-0.46.0-fb69b10c11.patch::version=0.46.0&hash=e0292b&locator=monaco-kusto%40workspace%3A."
+  checksum: 4b1f28cd5e0446cfc0b324ad0413b497132fce3b4487d3b6531a0640138d80033df37353e77650e41e5034a8691ee64d7b29bb6e1ecc8cd22fa42ea9549cea68
   languageName: node
   linkType: hard
 
@@ -7384,7 +7346,7 @@ __metadata:
     css-loader: ^6.8.1
     express: ^4.18.2
     html-webpack-plugin: ^5.5.3
-    monaco-editor: ~0.45.0
+    monaco-editor: ~0.46.0
     react: ^18.2.0
     react-dom: ^18.2.0
     style-loader: ^3.3.2
@@ -7501,7 +7463,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"msgpackr-extract@npm:^3.0.1":
+"msgpackr-extract@npm:^3.0.2":
   version: 3.0.2
   resolution: "msgpackr-extract@npm:3.0.2"
   dependencies:
@@ -7532,15 +7494,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"msgpackr@npm:1.8.5, msgpackr@npm:^1.5.4":
-  version: 1.8.5
-  resolution: "msgpackr@npm:1.8.5"
+"msgpackr@npm:^1.9.5, msgpackr@npm:^1.9.9":
+  version: 1.10.1
+  resolution: "msgpackr@npm:1.10.1"
   dependencies:
-    msgpackr-extract: ^3.0.1
+    msgpackr-extract: ^3.0.2
   dependenciesMeta:
     msgpackr-extract:
       optional: true
-  checksum: baa6d94fb6ea0592318c19a988f9379279e1882042c46585802c89720fcd8698e59819b55afb188b126f8ee3be792098791b2cfe03ad1defdb6011edb3b146ad
+  checksum: e422d18b01051598b23701eebeb4b9e2c686b9c7826b20f564724837ba2b5cd4af74c91a549eaeaf8186645cc95e8196274a4a19442aa3286ac611b98069c194
   languageName: node
   linkType: hard
 
@@ -7589,12 +7551,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-addon-api@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "node-addon-api@npm:4.3.0"
+"node-addon-api@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "node-addon-api@npm:6.1.0"
   dependencies:
     node-gyp: latest
-  checksum: 3de396e23cc209f539c704583e8e99c148850226f6e389a641b92e8967953713228109f919765abc1f4355e801e8f41842f96210b8d61c7dcc10a477002dcf00
+  checksum: 3a539510e677cfa3a833aca5397300e36141aca064cdc487554f2017110709a03a95da937e98c2a14ec3c626af7b2d1b6dabe629a481f9883143d0d5bff07bf2
   languageName: node
   linkType: hard
 
@@ -7614,17 +7576,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp-build-optional-packages@npm:5.0.6":
-  version: 5.0.6
-  resolution: "node-gyp-build-optional-packages@npm:5.0.6"
-  bin:
-    node-gyp-build-optional-packages: bin.js
-    node-gyp-build-optional-packages-optional: optional.js
-    node-gyp-build-optional-packages-test: build-test.js
-  checksum: 080656ae27e914035f8b259b3cd2e7e75538e219544a0378485714953eb5cf24391ea2e3d0c3cd4dabd75bebab966c1ac7c1432af9af0b2c2ef02bf9ec56ef99
-  languageName: node
-  linkType: hard
-
 "node-gyp-build-optional-packages@npm:5.0.7":
   version: 5.0.7
   resolution: "node-gyp-build-optional-packages@npm:5.0.7"
@@ -7633,6 +7584,19 @@ __metadata:
     node-gyp-build-optional-packages-optional: optional.js
     node-gyp-build-optional-packages-test: build-test.js
   checksum: bcb4537af15bcb3811914ea0db8f69284ca10db1cc7543a167a4c41ae4b9b5044b133f789fdadad0b7adc6931f6ae7def3c75b0bc7b05836881aae52400163e6
+  languageName: node
+  linkType: hard
+
+"node-gyp-build-optional-packages@npm:5.1.1":
+  version: 5.1.1
+  resolution: "node-gyp-build-optional-packages@npm:5.1.1"
+  dependencies:
+    detect-libc: ^2.0.1
+  bin:
+    node-gyp-build-optional-packages: bin.js
+    node-gyp-build-optional-packages-optional: optional.js
+    node-gyp-build-optional-packages-test: build-test.js
+  checksum: f3cb197862516e6879377adaa58142ae9013ab69c86cf2645f8b008db339354145d8ebd9140a13ec7ece5ce28a372ca7e14660379d3a3dd7b908a6f2743606e9
   languageName: node
   linkType: hard
 
@@ -7850,10 +7814,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ordered-binary@npm:^1.4.0":
-  version: 1.4.1
-  resolution: "ordered-binary@npm:1.4.1"
-  checksum: 274940b4ef983562e11371c84415c265432a4e1337ab85f8e7669eeab6afee8f655c6c12ecee1cd121aaf399c32f5c781b0d50e460bd42da004eba16dcc66574
+"ordered-binary@npm:^1.4.1":
+  version: 1.5.1
+  resolution: "ordered-binary@npm:1.5.1"
+  checksum: ec4d3a6bd7f8c84afec9def1e599e7d460a45d11f94d07b16fdf62db4d2bc16405d79ef0277c2fdf86332fd2539761278981787d2ecf52376ade8b678104a0e6
   languageName: node
   linkType: hard
 
@@ -7962,26 +7926,26 @@ __metadata:
   linkType: hard
 
 "parcel@npm:^2.0.0":
-  version: 2.9.3
-  resolution: "parcel@npm:2.9.3"
+  version: 2.11.0
+  resolution: "parcel@npm:2.11.0"
   dependencies:
-    "@parcel/config-default": 2.9.3
-    "@parcel/core": 2.9.3
-    "@parcel/diagnostic": 2.9.3
-    "@parcel/events": 2.9.3
-    "@parcel/fs": 2.9.3
-    "@parcel/logger": 2.9.3
-    "@parcel/package-manager": 2.9.3
-    "@parcel/reporter-cli": 2.9.3
-    "@parcel/reporter-dev-server": 2.9.3
-    "@parcel/reporter-tracer": 2.9.3
-    "@parcel/utils": 2.9.3
+    "@parcel/config-default": 2.11.0
+    "@parcel/core": 2.11.0
+    "@parcel/diagnostic": 2.11.0
+    "@parcel/events": 2.11.0
+    "@parcel/fs": 2.11.0
+    "@parcel/logger": 2.11.0
+    "@parcel/package-manager": 2.11.0
+    "@parcel/reporter-cli": 2.11.0
+    "@parcel/reporter-dev-server": 2.11.0
+    "@parcel/reporter-tracer": 2.11.0
+    "@parcel/utils": 2.11.0
     chalk: ^4.1.0
     commander: ^7.0.0
     get-port: ^4.2.0
   bin:
     parcel: lib/bin.js
-  checksum: d9b9c0083f49ecb7e35f3da0322fa71912158a847463e877bfa7f170063f3d66a8d57dd5b3f5b69a86ccce6ef07c7a70504b1191bbd477f0c908071516d13749
+  checksum: 1990c725049161755c3556effc8d940fb6d05edfd2f2a74bb507d0d9bdd17d2e6d73ac45d1ded9ff31d94549a364cd109c2827de6a0a956e672aa0999f283879
   languageName: node
   linkType: hard
 
@@ -10144,13 +10108,6 @@ __metadata:
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
-  languageName: node
-  linkType: hard
-
-"xxhash-wasm@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "xxhash-wasm@npm:0.4.2"
-  checksum: 747b32fcfed1dc9a1e7592b134e4e65794bc10fd5d32515792e486bf4d0b65f9dec790cfc49ce2f9c01dd02e3593c3a6cd51df1ef37adf003c5bbd386c43c64d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Patch monaco-editor in order to get esm-parcel sample working
  - Aside: Looks like CI didn't catch this?
- Fix both `0.45.0` and `0.46.0` monaco-editor versions resolve in the repo
- Bumped parcel version