### PR TITLE
chore: add auto closing pairs for double quotes and brackets

### DIFF
--- a/package/src/kustoMode.ts
+++ b/package/src/kustoMode.ts
@@ -173,6 +173,12 @@ export function setupMode(
             lineComment: '//',
             blockComment: null,
         },
+        autoClosingPairs: [
+            { open: '"', close: '"' },
+            { open: '(', close: ')' },
+            { open: '[', close: ']' },
+            { open: '{', close: '}' },
+        ],
     });
 
     return kustoWorker;


### PR DESCRIPTION
align auto closing pairs with the behavior of modern ide's 

before: 
![before](https://github.com/Azure/monaco-kusto/assets/9433571/165ed4ca-c78e-42ed-bdb9-cf96ffc1aef3)

after:
![after](https://github.com/Azure/monaco-kusto/assets/9433571/b4bfb96f-b02d-4604-80fb-7b16b39d6d83)

