### PR TITLE
completion items > fix ordering bug

### DIFF
--- a/package/src/languageServiceManager/competionItemSort.ts
+++ b/package/src/languageServiceManager/competionItemSort.ts
@@ -5,20 +5,25 @@ export const createSortingText = (priority: number) => {
 };
 
 export function sortByMatchTextKeepingKindOrder(items: k2.CompletionItem[]) {
-    const groupedByKind = groupContiguousByKind(items);
+    const groupedByKind = groupContiguousByKindAndFirstChar(items);
     const sortedGroupedItems = sortGroupedItems(groupedByKind);
     return sortedGroupedItems.flat();
 }
 
 function sortGroupedItems(groupedItems: k2.CompletionItem[][]) {
-    return groupedItems.map((group) => group.sort((i1, i2) => i1.MatchText.localeCompare(i2.MatchText)));
+    return groupedItems.map((group) => {
+        if (group.length === 1) return group;
+        return group.sort((i1, i2) => i1.MatchText.localeCompare(i2.MatchText));
+    });
 }
 
-function groupContiguousByKind(items: k2.CompletionItem[]) {
+function groupContiguousByKindAndFirstChar(items: k2.CompletionItem[]) {
     return items.reduce((result: k2.CompletionItem[][], item: k2.CompletionItem) => {
         const lastGroup = last(result);
+        const lastItem = last(lastGroup);
 
-        const shouldCreateNewGroup = !lastGroup || last(lastGroup)?.Kind !== item.Kind;
+        const shouldCreateNewGroup =
+            !lastItem || lastItem.Kind !== item.Kind || lastItem.MatchText[0] !== item.MatchText[0];
         if (shouldCreateNewGroup) result.push([]);
         last(result).push(item);
 
@@ -27,5 +32,6 @@ function groupContiguousByKind(items: k2.CompletionItem[]) {
 }
 
 function last<T>(array: T[]): T | undefined {
+    if (!array) return undefined;
     return array.length > 0 ? array[array.length - 1] : undefined;
 }

--- a/package/src/languageServiceManager/competionItemSort.ts
+++ b/package/src/languageServiceManager/competionItemSort.ts
@@ -4,34 +4,81 @@ export const createSortingText = (priority: number) => {
     return priority.toString().padStart(10, '0');
 };
 
-export function sortByMatchTextKeepingKindOrder(items: k2.CompletionItem[]) {
-    const groupedByKind = groupContiguousByKindAndFirstChar(items);
-    const sortedGroupedItems = sortGroupedItems(groupedByKind);
-    return sortedGroupedItems.flat();
+export function sortCompletionItems(items: k2.CompletionItem[]) {
+    return (
+        items
+            .sort((i1, i2) => i1.MatchText.localeCompare(i2.MatchText))
+            // @ts-ignore
+            .sort((i1, i2) => i1.Priority - i2.Priority)
+            .sort((i1, i2) => getOrderingRank(i1) - getOrderingRank(i2))
+    );
 }
 
-function sortGroupedItems(groupedItems: k2.CompletionItem[][]) {
-    return groupedItems.map((group) => {
-        if (group.length === 1) return group;
-        return group.sort((i1, i2) => i1.MatchText.localeCompare(i2.MatchText));
-    });
+const CompletionKind = Kusto.Language.Editor.CompletionKind;
+const CompletionRank = Kusto.Language.Editor.CompletionRank;
+
+function getOrderingRank(item: k2.CompletionItem) {
+    switch (item.Kind) {
+        case CompletionKind.Example:
+            return CompletionRank.Literal;
+
+        case CompletionKind.QueryPrefix:
+            return CompletionRank.Keyword;
+
+        case CompletionKind.Keyword:
+            return CompletionRank.Keyword;
+
+        case CompletionKind.AggregateFunction:
+            return CompletionRank.Aggregate;
+
+        case CompletionKind.Column:
+            return CompletionRank.Column;
+
+        case CompletionKind.Table:
+            return CompletionRank.Table;
+
+        case CompletionKind.MaterialiedView:
+        case CompletionKind.EntityGroup:
+        case CompletionKind.Graph:
+            return CompletionRank.Entity;
+
+        case CompletionKind.Variable:
+        case CompletionKind.Parameter:
+            if (item.DisplayText == '$left' || item.DisplayText == '$right') {
+                return CompletionRank.Literal;
+            }
+            return CompletionRank.Variable;
+
+        case CompletionKind.BuiltInFunction:
+        case CompletionKind.LocalFunction:
+        case CompletionKind.DatabaseFunction:
+            return CompletionRank.Function;
+
+        case CompletionKind.ScalarInfix: {
+            const firstChar = item.DisplayText[0];
+            return isLetterOrDigit(firstChar) ? CompletionRank.StringOperator : CompletionRank.MathOperator;
+        }
+
+        case CompletionKind.ScalarPrefix:
+        case CompletionKind.TabularPrefix:
+        case CompletionKind.TabularSuffix:
+        case CompletionKind.Identifier:
+        case CompletionKind.Cluster:
+        case CompletionKind.Database:
+        case CompletionKind.Punctuation:
+        case CompletionKind.Syntax:
+        case CompletionKind.Unknown:
+        case CompletionKind.RenderChart:
+        default:
+            return CompletionRank.Other;
+    }
 }
 
-function groupContiguousByKindAndFirstChar(items: k2.CompletionItem[]) {
-    return items.reduce((result: k2.CompletionItem[][], item: k2.CompletionItem) => {
-        const lastGroup = last(result);
-        const lastItem = last(lastGroup);
-
-        const shouldCreateNewGroup =
-            !lastItem || lastItem.Kind !== item.Kind || lastItem.MatchText[0] !== item.MatchText[0];
-        if (shouldCreateNewGroup) result.push([]);
-        last(result).push(item);
-
-        return result;
-    }, []);
-}
-
-function last<T>(array: T[]): T | undefined {
-    if (!array) return undefined;
-    return array.length > 0 ? array[array.length - 1] : undefined;
+function isLetterOrDigit(char: string): boolean {
+    const code = char.charCodeAt(0);
+    return (
+        (code >= 48 && code <= 57) || // 0-9
+        (code >= 65 && code <= 90) || // A-Z
+        (code >= 97 && code <= 122) // a-z
+    );
 }

--- a/package/src/languageServiceManager/completionItemSort.spec.ts
+++ b/package/src/languageServiceManager/completionItemSort.spec.ts
@@ -1,6 +1,6 @@
 import k2 = Kusto.Language.Editor;
 import { test, describe, expect } from '@jest/globals';
-import { createSortingText, sortByMatchTextKeepingKindOrder } from './competionItemSort';
+import { createSortingText, sortCompletionItems } from './competionItemSort';
 import { kustoCompletionItemBuilder } from '../../tests/unit/builders/KustoCompletionItem';
 
 describe('createSortingText', () => {
@@ -27,23 +27,44 @@ describe('createSortingText', () => {
     });
 });
 
-describe('sortByMatchTextKeepingKindOrder', () => {
+describe('sortCompletionItems', () => {
     test('should sort by match text grouped by kind and first char', () => {
         const items = [
-            kustoCompletionItemBuilder().withMatchText('where').withKind(k2.CompletionKind.AggregateFunction).build(),
             kustoCompletionItemBuilder()
                 .withMatchText('count_distinct')
+                .withPriority(2)
                 .withKind(k2.CompletionKind.AggregateFunction)
                 .build(),
-            kustoCompletionItemBuilder().withMatchText('count').withKind(k2.CompletionKind.AggregateFunction).build(),
-            kustoCompletionItemBuilder().withMatchText('bin_at').withKind(k2.CompletionKind.BuiltInFunction).build(),
-            kustoCompletionItemBuilder().withMatchText('bin').withKind(k2.CompletionKind.BuiltInFunction).build(),
-            kustoCompletionItemBuilder().withMatchText('avg').withKind(k2.CompletionKind.AggregateFunction).build(),
+            kustoCompletionItemBuilder()
+                .withMatchText('count')
+                .withPriority(2)
+                .withKind(k2.CompletionKind.AggregateFunction)
+                .build(),
+            kustoCompletionItemBuilder()
+                .withMatchText('where')
+                .withPriority(0)
+                .withKind(k2.CompletionKind.AggregateFunction)
+                .build(),
+            kustoCompletionItemBuilder()
+                .withMatchText('bin_at')
+                .withPriority(2)
+                .withKind(k2.CompletionKind.BuiltInFunction)
+                .build(),
+            kustoCompletionItemBuilder()
+                .withMatchText('bin')
+                .withPriority(2)
+                .withKind(k2.CompletionKind.BuiltInFunction)
+                .build(),
+            kustoCompletionItemBuilder()
+                .withMatchText('avg')
+                .withPriority(2)
+                .withKind(k2.CompletionKind.AggregateFunction)
+                .build(),
         ];
 
-        const sortedItems = sortByMatchTextKeepingKindOrder(items);
+        const sortedItems = sortCompletionItems(items);
 
         const results = sortedItems.map((item) => item.MatchText);
-        expect(results).toEqual(['where', 'count', 'count_distinct', 'bin', 'bin_at', 'avg']);
+        expect(results).toEqual(['where', 'avg', 'count', 'count_distinct', 'bin', 'bin_at']);
     });
 });

--- a/package/src/languageServiceManager/completionItemSort.spec.ts
+++ b/package/src/languageServiceManager/completionItemSort.spec.ts
@@ -28,35 +28,22 @@ describe('createSortingText', () => {
 });
 
 describe('sortByMatchTextKeepingKindOrder', () => {
-    test('should sort by match text grouped by kind', () => {
-        const item1 = kustoCompletionItemBuilder()
-            .withMatchText('count_distinct')
-            .withKind(k2.CompletionKind.AggregateFunction)
-            .build();
-        const item2 = kustoCompletionItemBuilder()
-            .withMatchText('count')
-            .withKind(k2.CompletionKind.AggregateFunction)
-            .build();
-        const item3 = kustoCompletionItemBuilder()
-            .withMatchText('bin_at')
-            .withKind(k2.CompletionKind.BuiltInFunction)
-            .build();
-        const item4 = kustoCompletionItemBuilder()
-            .withMatchText('bin')
-            .withKind(k2.CompletionKind.BuiltInFunction)
-            .build();
-        const item5 = kustoCompletionItemBuilder()
-            .withMatchText('avg')
-            .withKind(k2.CompletionKind.AggregateFunction)
-            .build();
-        const items = [item1, item2, item3, item4, item5];
+    test('should sort by match text grouped by kind and first char', () => {
+        const items = [
+            kustoCompletionItemBuilder().withMatchText('where').withKind(k2.CompletionKind.AggregateFunction).build(),
+            kustoCompletionItemBuilder()
+                .withMatchText('count_distinct')
+                .withKind(k2.CompletionKind.AggregateFunction)
+                .build(),
+            kustoCompletionItemBuilder().withMatchText('count').withKind(k2.CompletionKind.AggregateFunction).build(),
+            kustoCompletionItemBuilder().withMatchText('bin_at').withKind(k2.CompletionKind.BuiltInFunction).build(),
+            kustoCompletionItemBuilder().withMatchText('bin').withKind(k2.CompletionKind.BuiltInFunction).build(),
+            kustoCompletionItemBuilder().withMatchText('avg').withKind(k2.CompletionKind.AggregateFunction).build(),
+        ];
 
         const sortedItems = sortByMatchTextKeepingKindOrder(items);
 
-        expect(sortedItems[0].MatchText).toBe('count');
-        expect(sortedItems[1].MatchText).toBe('count_distinct');
-        expect(sortedItems[2].MatchText).toBe('bin');
-        expect(sortedItems[3].MatchText).toBe('bin_at');
-        expect(sortedItems[4].MatchText).toBe('avg');
+        const results = sortedItems.map((item) => item.MatchText);
+        expect(results).toEqual(['where', 'count', 'count_distinct', 'bin', 'bin_at', 'avg']);
     });
 });

--- a/package/src/languageServiceManager/kustoLanguageService.ts
+++ b/package/src/languageServiceManager/kustoLanguageService.ts
@@ -20,7 +20,7 @@ import { Database, EntityGroup, getCslTypeNameFromClrType, getEntityDataTypeFrom
 import type { RenderOptions, VisualizationType, RenderOptionKeys, RenderInfo } from './renderInfo';
 import type { ClusterReference, DatabaseReference } from '../types';
 import { Mutable } from '../util';
-import { createSortingText, sortByMatchTextKeepingKindOrder } from './competionItemSort';
+import { createSortingText, sortCompletionItems } from './competionItemSort';
 
 let List = System.Collections.Generic.List$1;
 
@@ -419,7 +419,7 @@ class KustoLanguageService implements LanguageService {
             });
         }
         const itemsAsArray = this.toArray<k2.CompletionItem>(completionItems.Items);
-        const sortedArray = sortByMatchTextKeepingKindOrder(itemsAsArray);
+        const sortedArray = sortCompletionItems(itemsAsArray);
         let items: ls.CompletionItem[] = sortedArray
             .filter(
                 (item) =>

--- a/package/tests/integration/completion-items.spec.ts
+++ b/package/tests/integration/completion-items.spec.ts
@@ -50,5 +50,12 @@ test.describe('completion items', () => {
             await page.keyboard.type('ime');
             await expect(model.intellisense().option(0).locator).toHaveText('StartTime');
         });
+
+        test('suggests "where" after table name and Enter', async ({ page }) => {
+            await model.intellisense().wait();
+
+            const firstOption = model.intellisense().option(0);
+            await expect(firstOption.locator).toContainText('where');
+        });
     });
 });

--- a/package/tests/unit/builders/KustoCompletionItem.ts
+++ b/package/tests/unit/builders/KustoCompletionItem.ts
@@ -1,11 +1,16 @@
 import k2 = Kusto.Language.Editor;
 import { faker } from '@faker-js/faker';
 
+interface KustoCompletionItem extends k2.CompletionItem {
+    Priority: number;
+}
+
 export function kustoCompletionItemBuilder() {
-    const completionItem: k2.CompletionItem = {
+    const completionItem: KustoCompletionItem = {
         Kind: k2.CompletionKind.Unknown,
         DisplayText: faker.lorem.word(),
         MatchText: null,
+        Priority: null,
         ApplyTexts: null,
         BeforeText: null,
         AfterText: null,
@@ -30,6 +35,10 @@ export function kustoCompletionItemBuilder() {
         },
         withMatchText: (matchText: string) => {
             completionItem.MatchText = matchText;
+            return builder;
+        },
+        withPriority: (priority: number) => {
+            completionItem.Priority = priority;
             return builder;
         },
         build: (): k2.CompletionItem => completionItem,


### PR DESCRIPTION
This PR copies the sort logic from the language service C# code. 
It sorts by MatchText instead of DisplayText to avoid bugs caused by the ASCII value-based sorting order in JavaScript, where special characters such as '(' have lower values than alphabetic characters. This issue results in unexpected order, such as 'count()' appearing after 'count_distinct()' in the IntelliSense results.

This is a temporary fix until the language service is updated. 
The reasons for this being temporary are, first, to avoid code duplication, and second, because I had to use ts-ignore for the Priority property on CompletionItem since it is internal.