### PR TITLE
exclude punctuation-only syntax from completion items

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,19 +85,23 @@ Every PR should come with a test that checks it.
 
 ## Changelog
 
+### 11.2.2
+
+-   fix: Exclude punctuation-only syntax from completion items.
+
 ### 11.2.1
 
--   feat: upgrade language-service-next to 11.6.1.
+-   feat: Upgrade language-service-next to 11.6.1.
 
 -   ### 11.2.0
 
--   feat: fix bugs related to last version upgrade.
--   feat: upgrade language-service-next to 11.6.0.
+-   feat: Fix bugs related to last version upgrade.
+-   feat: Upgrade language-service-next to 11.6.0.
 
 ### 11.1.0
 
 -   feat: Modify the ordering of completion items so that columns always appear at the top.
--   feat: upgrade language-service-next to 11.5.6.
+-   feat: Upgrade language-service-next to 11.5.6.
 
 ### 11.0.0
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Every PR should come with a test that checks it.
 
 ## Changelog
 
-### 11.2.2
+### 11.3.0
 
 -   fix: Exclude punctuation-only syntax from completion items.
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "11.2.1",
+    "version": "11.2.2",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "11.2.2",
+    "version": "11.3.0",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/languageServiceManager/kustoLanguageService.ts
+++ b/package/src/languageServiceManager/kustoLanguageService.ts
@@ -338,7 +338,9 @@ class KustoLanguageService implements LanguageService {
 
         const { includeExtendedSyntax } = this._languageSettings.completionOptions;
         this._completionOptions =
-            Kusto.Language.Editor.CompletionOptions.Default.WithIncludeExtendedSyntax(includeExtendedSyntax);
+            Kusto.Language.Editor.CompletionOptions.Default.WithIncludeExtendedSyntax(
+                includeExtendedSyntax
+            ).WithIncludePunctuationOnlySyntax(false);
 
         // Since we're still reverting to V1 intellisense for control commands, we need to update the rules provider
         // (which is a notion of V1 intellisense).

--- a/package/tests/integration/completion-items.spec.ts
+++ b/package/tests/integration/completion-items.spec.ts
@@ -32,6 +32,14 @@ test.describe('completion items', () => {
         await expect(options.locator).toHaveCount(2);
     });
 
+    test('exclude punctuation only syntax', async ({ page }) => {
+        await page.keyboard.type('lookup kind = ');
+
+        await model.intellisense().wait();
+        const options = model.intellisense().options();
+        await expect(options.locator.first()).not.toContainText('[');
+    });
+
     test.describe('ordered by relevance', () => {
         test('verify alphabetical order of functions', async ({ page }) => {
             await page.keyboard.type('summarize coun');


### PR DESCRIPTION
Completion items used to include results like [ or .. Now they don't :)