### PR TITLE
fix: dark mode colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Every PR should come with a test that checks it.
 
 ## Changelog
 
+### 12.0.5
+
+-   fix: Dark mode colors are now more readable.
+
 ### 12.0.4
 
 -   fix: Explicitly export getRangeHtml from monaco.contribution to fix an issue with parcel build.

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "12.0.4",
+    "version": "12.0.5",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/syntaxHighlighting/themes.ts
+++ b/package/src/syntaxHighlighting/themes.ts
@@ -96,9 +96,9 @@ const dark: monaco.editor.IStandaloneThemeData = {
         { token: Token.Command, foreground: colors.skyBlue },
         { token: Token.Keyword, foreground: colors.skyBlue },
         { token: Token.MaterializedView, foreground: colors.softGold },
-        { token: Token.SchemaMember, foreground: colors.black },
-        { token: Token.SignatureParameter, foreground: colors.black },
-        { token: Token.Option, foreground: colors.black },
+        { token: Token.SchemaMember, foreground: colors.white },
+        { token: Token.SignatureParameter, foreground: colors.white },
+        { token: Token.Option, foreground: colors.white },
     ],
     colors: {
         'editor.background': colors.jetBlack,


### PR DESCRIPTION
Fixed an issue where some colors were not visible in dark mode due to a black-on-black setting. Updated the colors to white for better visibility.