### PR TITLE
fix: rollback KQL color change

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Every PR should come with a test that checks it.
 
 ## Changelog
 
+### 12.0.7
+
+-   revert: KQL color contrast for query operators change.
+
 ### 12.0.6
 
 -   fix: KQL color contrast for query operators now complies with accessibility guidelines.

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "12.0.6",
+    "version": "12.0.7",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/syntaxHighlighting/themes.ts
+++ b/package/src/syntaxHighlighting/themes.ts
@@ -17,7 +17,7 @@ const colors = {
     paleChestnut: '#D69D85',
     paleVioletRed: '#DB7093',
     firebrick: '#B22222',
-    orangeRed: '#D93900',
+    orangeRed: '#FF4500',
     mediumVioletRed: '#C71585',
     magenta: '#FF00FF', // for debugging
     darkOrchid: '#9932CC',


### PR DESCRIPTION
After adjusting the color to meet accessibility tool contrast guidelines, we decided to revert to the original KE color. 
This PR is to prevent accidental package updates that could result in an incorrect color palette for KQL.