### PR TITLE
avoid race condition on worker disposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Every PR should come with a test that checks it.
 
 ## Changelog
 
+### 12.0.11
+
+-   fix: avoid race condition on worker disposal
+
 ### 12.0.10
 
 -   fix: Parameter docstrings not shown

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "12.0.10",
+    "version": "12.0.11",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/monaco.contribution.ts
+++ b/package/src/monaco.contribution.ts
@@ -102,11 +102,7 @@ export const kustoDefaults = new LanguageServiceDefaultsImpl(defaultLanguageSett
 
 let disposable: monaco.IDisposable;
 monaco.languages.onLanguage('kusto', async () => {
-    disposable = await withMode((mode) => mode.setupMode(kustoDefaults, monaco as typeof globalThis.monaco));
-});
-
-monaco.editor.onWillDisposeModel((model) => {
-    disposable.dispose();
+    await withMode((mode) => mode.setupMode(kustoDefaults, monaco as typeof globalThis.monaco));
 });
 
 monaco.languages.register({


### PR DESCRIPTION
## Disposing of Kusto Worker on `setLanguageSettings` Call

Every time `setLanguageSettings` is called, the old Kusto worker is disposed of, and a new one is created. This means that if the old worker is in the middle of handling requests, those requests will be terminated before completion.

### What This Causes

We register the semantic token provider after `worker.setSchema` has completed. Since `setLanguageSettings` is called when entering the query page editor, the worker gets disposed of during that call, leaving the `setSchema` promise unresolved. As a result, the semantic tokens provider is not registered.

### The Workaround Solution

The solution is a bit of a workaround—apologies for that. I wait for 5 seconds before disposing of the old worker to allow it to finish processing previous requests. Before that, I reset the `workerManager` private member of `workerDetails`, so new requests will create a new worker and be applied to the new instance.

### Is Disposing the Old Worker Necessary?

I did consider whether disposing of the old worker when `setLanguageSettings` is called is truly necessary. I believe it isn’t. However, Noam and I decided not to remove this behavior currently because it might impact unknown scenarios that we cannot easily test. Therefore, this change is not suitable when a Quick Fix Engineering (QFE) is required.

