### PR TITLE
Fix: Correct caching of completion items for queries on different lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Every PR should come with a test that checks it.
 
 ## Changelog
 
+### 12.0.15
+
+-   fix: executing the same query on a different line now correctly displays completion items.
+
 ### 12.0.14
 
 -   feat: highlight matching brackets.

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "12.0.14",
+    "version": "12.0.15",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/completionCacheManager/completionCacheManager.spec.ts
+++ b/package/src/completionCacheManager/completionCacheManager.spec.ts
@@ -7,7 +7,10 @@ describe('completionCacheManager', () => {
     let completionCacheManager: CompletionCacheManager;
     const mockGetFromLanguageService: jest.MockedFunction<GetFromLanguageService> = jest.fn();
     const resource = {} as monaco.Uri;
-    const position = {} as ls.Position;
+    const position = {
+        line: 0,
+        character: 0,
+    } as ls.Position;
 
     beforeEach(() => {
         mockGetFromLanguageService.mockClear();
@@ -42,6 +45,15 @@ describe('completionCacheManager', () => {
 
         test('calls language service when the current word is contained in the previous word', async () => {
             await completionCacheManager.getCompletionItems('a', resource, position);
+            expect(mockGetFromLanguageService).toHaveBeenCalledTimes(1);
+        });
+
+        test('calls language service when the position line has changed', async () => {
+            const newPosition = {
+                line: 1,
+                character: 0,
+            };
+            await completionCacheManager.getCompletionItems('ab', resource, newPosition);
             expect(mockGetFromLanguageService).toHaveBeenCalledTimes(1);
         });
     });

--- a/package/src/completionCacheManager/completionCacheManager.ts
+++ b/package/src/completionCacheManager/completionCacheManager.ts
@@ -4,15 +4,18 @@ import * as ls from 'vscode-languageserver-types';
 export const createCompletionCacheManager = (getFromLanguageService: GetFromLanguageService) => {
     let completionList: Promise<ls.CompletionList> | undefined;
     let lastWord: string | undefined;
+    let lastPosition: ls.Position | undefined;
 
     return {
         getCompletionItems: (word: string | undefined, resource: monaco.Uri, position: ls.Position) => {
-            const shouldGetItems = !lastWord || !word || !word?.includes(lastWord);
+            const didLinePositionChanged = !lastPosition || lastPosition.line !== position.line;
+            const shouldGetItems = didLinePositionChanged || !lastWord || !word || !word?.includes(lastWord);
             if (shouldGetItems) {
                 completionList = getFromLanguageService(resource, position);
             }
 
             lastWord = word;
+            lastPosition = position;
             return completionList;
         },
     };


### PR DESCRIPTION
This PR fixes an issue where running the same query on two different lines causes the second execution to fail. The bug occurred because the cached completion items, which contain a range from the first query, were incorrectly reused by the completionCacheManager even when the cursor had moved to a different line. As a result, the Monaco Editor failed to display completion items for the second query.

The fix ensures that if the cursor's line has changed, the language service is queried again to calculate the correct completion items, rather than relying on the outdated cache.