### PR TITLE
Fix getWordAtPosition in Kusto to include hyphenated words (e.g., "project-re")

### DIFF
--- a/package/src/kustoMode.ts
+++ b/package/src/kustoMode.ts
@@ -146,4 +146,5 @@ const languageConfiguration: LanguageConfiguration = {
         ['(', ')'],
     ],
     colorizedBracketPairs: [],
+    wordPattern: /[a-zA-Z0-9\-_]+/g,
 };

--- a/package/tests/integration/completion-items.spec.ts
+++ b/package/tests/integration/completion-items.spec.ts
@@ -1,15 +1,16 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Locator } from '@playwright/test';
 import { createMonaKustoModel, MonaKustoModel, loadPageAndWait } from './testkit';
 
 test.describe('completion items', () => {
     let model: MonaKustoModel;
+    let editor: Locator;
 
     test.beforeEach(async ({ page }) => {
         await loadPageAndWait(page);
         model = createMonaKustoModel(page);
 
         const initialValue = 'StormEvents';
-        const editor = model.editor().locator;
+        editor = model.editor().locator;
         await editor.focus();
         await editor.fill(initialValue);
         await model.intellisense().wait();
@@ -80,5 +81,15 @@ test.describe('completion items', () => {
 
         const focusedItem = model.intellisense().focused();
         expect(focusedItem.locator).toHaveText('timespan()');
+    });
+
+    test('Intellisense should remain open when typing "project-re"', async ({ page }) => {
+        await editor.pressSequentially('project');
+        await model.intellisense().wait();
+        await editor.pressSequentially('-re');
+        await model.intellisense().wait();
+
+        const options = model.intellisense().options();
+        await expect(options.locator).toHaveCount(2);
     });
 });


### PR DESCRIPTION
## Fix getWordAtPosition to Support Hyphenated Identifiers in Kusto

### Summary
This PR updates the Kusto language configuration to treat hyphenated words (e.g., `"project-re"`) as a single word in Monaco Editor.

### Problem
Previously, `editor.getModel().getWordAtPosition()` would return only `"re"` when the cursor was placed inside `"project-re"`. This is because the default word pattern treated the hyphen (`-`) as a word separator.

### Fix
- Updated the `wordPattern` in the Kusto language configuration to include hyphens as part of valid word characters.
- New regex: `/[a-zA-Z0-9\-_]+/g`
