### PR TITLE
fix: support multiline bracketed strings in semantic tokenization

### DIFF
--- a/package/src/syntaxHighlighting/SemanticTokensProvider.ts
+++ b/package/src/syntaxHighlighting/SemanticTokensProvider.ts
@@ -20,11 +20,11 @@ export class SemanticTokensProvider implements monaco.languages.DocumentSemantic
         const classifications = await this.classificationsGetter(resource);
         const semanticTokens = classifications.map((classification, index) => {
             const previousClassification = classifications[index - 1];
-            return semanticTokenMaker(classification, previousClassification);
+            return semanticTokenMaker(classification, previousClassification, model);
         });
 
         return {
-            data: new Uint32Array(semanticTokens.flat()),
+            data: new Uint32Array(semanticTokens.flat(2)),
             resultId: model.getVersionId().toString(),
         };
     }
@@ -33,13 +33,46 @@ export class SemanticTokensProvider implements monaco.languages.DocumentSemantic
 }
 
 const emptyClassification = { line: 0, character: 0, length: 0, kind: 0 };
+
 function semanticTokenMaker(
     classification: ClassificationRange,
-    previousClassification: ClassificationRange = emptyClassification
-): DocumentSemanticToken {
+    previous: ClassificationRange = emptyClassification,
+    model: editor.ITextModel
+): DocumentSemanticToken | DocumentSemanticToken[] {
     const { line, character, length, kind } = classification;
-    const deltaLine = line - previousClassification.line;
-    const deltaStart = deltaLine ? character : character - previousClassification.character;
 
-    return [deltaLine, deltaStart, length, kind, 0];
+    const prevLine = shouldWrapLine(previous, model) ? previous.line + 1 : previous.line;
+    const deltaLine = line - prevLine;
+    const deltaChar = deltaLine ? character : character - previous.character;
+
+    if (shouldWrapLine(classification, model)) {
+        return splitTokenAcrossLines(deltaLine, deltaChar, character, length, kind, model, line);
+    }
+
+    return [deltaLine, deltaChar, length, kind, 0];
+}
+
+function shouldWrapLine(classification: ClassificationRange, model: editor.ITextModel): boolean {
+    const { line, character, length } = classification;
+    const lineLength = model.getLineLength(line + 1);
+    return character + length > lineLength;
+}
+
+function splitTokenAcrossLines(
+    deltaLine: number,
+    deltaChar: number,
+    character: number,
+    length: number,
+    kind: number,
+    model: editor.ITextModel,
+    line: number
+): DocumentSemanticToken[] {
+    const lineLength = model.getLineLength(line + 1);
+    const firstPartLength = lineLength - character + 1;
+    const secondPartLength = length - firstPartLength;
+
+    return [
+        [deltaLine, deltaChar, firstPartLength, kind, 0],
+        [deltaLine + 1, 0, secondPartLength, kind, 0],
+    ];
 }

--- a/package/src/syntaxHighlighting/SemanticTokensProvider.ts
+++ b/package/src/syntaxHighlighting/SemanticTokensProvider.ts
@@ -18,13 +18,29 @@ export class SemanticTokensProvider implements monaco.languages.DocumentSemantic
     async provideDocumentSemanticTokens(model: editor.ITextModel) {
         const resource = model.uri;
         const classifications = await this.classificationsGetter(resource);
-        const semanticTokens = classifications.map((classification, index) => {
-            const previousClassification = classifications[index - 1];
-            return semanticTokenMaker(classification, previousClassification, model);
-        });
+
+        const tokens: DocumentSemanticToken[] = [];
+        let prevLine = 0;
+        let prevChar = 0;
+
+        for (const classification of classifications) {
+            const parts = toSemanticTokens(classification, model);
+
+            for (const part of parts) {
+                const [absLine, absChar, length, kind, modifiers] = part;
+
+                const deltaLine = absLine - prevLine;
+                const deltaChar = deltaLine === 0 ? absChar - prevChar : absChar;
+
+                tokens.push([deltaLine, deltaChar, length, kind, modifiers]);
+
+                prevLine = absLine;
+                prevChar = absChar;
+            }
+        }
 
         return {
-            data: new Uint32Array(semanticTokens.flat(2)),
+            data: new Uint32Array(tokens.flat(2)),
             resultId: model.getVersionId().toString(),
         };
     }
@@ -32,47 +48,25 @@ export class SemanticTokensProvider implements monaco.languages.DocumentSemantic
     releaseDocumentSemanticTokens() {}
 }
 
-const emptyClassification = { line: 0, character: 0, length: 0, kind: 0 };
-
-function semanticTokenMaker(
-    classification: ClassificationRange,
-    previous: ClassificationRange = emptyClassification,
-    model: editor.ITextModel
-): DocumentSemanticToken | DocumentSemanticToken[] {
+function toSemanticTokens(classification: ClassificationRange, model: editor.ITextModel): DocumentSemanticToken[] {
     const { line, character, length, kind } = classification;
+    const tokens: DocumentSemanticToken[] = [];
 
-    const prevLine = shouldWrapLine(previous, model) ? previous.line + 1 : previous.line;
-    const deltaLine = line - prevLine;
-    const deltaChar = deltaLine ? character : character - previous.character;
+    let remainingLength = length;
+    let currentLine = line;
+    let currentChar = character;
 
-    if (shouldWrapLine(classification, model)) {
-        return splitTokenAcrossLines(deltaLine, deltaChar, character, length, kind, model, line);
+    while (remainingLength > 0 && currentLine < model.getLineCount()) {
+        const lineLength = model.getLineLength(currentLine + 1);
+        const available = lineLength - currentChar + 1;
+        const tokenLength = Math.min(remainingLength, available);
+
+        tokens.push([currentLine, currentChar, tokenLength, kind, 0]);
+
+        remainingLength -= tokenLength;
+        currentLine++;
+        currentChar = 0; // reset for next line
     }
 
-    return [deltaLine, deltaChar, length, kind, 0];
-}
-
-function shouldWrapLine(classification: ClassificationRange, model: editor.ITextModel): boolean {
-    const { line, character, length } = classification;
-    const lineLength = model.getLineLength(line + 1);
-    return character + length > lineLength;
-}
-
-function splitTokenAcrossLines(
-    deltaLine: number,
-    deltaChar: number,
-    character: number,
-    length: number,
-    kind: number,
-    model: editor.ITextModel,
-    line: number
-): DocumentSemanticToken[] {
-    const lineLength = model.getLineLength(line + 1);
-    const firstPartLength = lineLength - character + 1;
-    const secondPartLength = length - firstPartLength;
-
-    return [
-        [deltaLine, deltaChar, firstPartLength, kind, 0],
-        [deltaLine + 1, 0, secondPartLength, kind, 0],
-    ];
+    return tokens;
 }

--- a/package/src/syntaxHighlighting/types.ts
+++ b/package/src/syntaxHighlighting/types.ts
@@ -1,31 +1,31 @@
 export type ClassificationKind = Kusto.Language.Editor.ClassificationKind;
 
 export enum Token {
-    PlainText = 'plainText',
-    Comment = 'comment',
-    Punctuation = 'punctuation',
-    Directive = 'directive',
-    Literal = 'literal',
-    StringLiteral = 'stringLiteral',
-    Type = 'type',
-    Column = 'column',
-    Table = 'table',
-    Database = 'database',
-    Function = 'function',
-    Parameter = 'parameter',
-    Variable = 'variable',
-    Identifier = 'identifier',
-    ClientParameter = 'clientParameter',
-    QueryParameter = 'queryParameter',
-    ScalarParameter = 'scalarParameter',
-    MathOperator = 'mathOperator',
-    QueryOperator = 'queryOperator',
-    Command = 'command',
-    Keyword = 'keyword',
-    MaterializedView = 'materializedView',
-    SchemaMember = 'schemaMember',
-    SignatureParameter = 'signatureParameter',
-    Option = 'option',
+    PlainText = 'plainText', // 0
+    Comment = 'comment', // 1
+    Punctuation = 'punctuation', // 2
+    Directive = 'directive', // 3
+    Literal = 'literal', // 4
+    StringLiteral = 'stringLiteral', // 5
+    Type = 'type', // 6
+    Column = 'column', // 7
+    Table = 'table', // 8
+    Database = 'database', // 9
+    Function = 'function', // 10
+    Parameter = 'parameter', // 11
+    Variable = 'variable', // 12
+    Identifier = 'identifier', // 13
+    ClientParameter = 'clientParameter', // 14
+    QueryParameter = 'queryParameter', // 15
+    ScalarParameter = 'scalarParameter', // 16
+    MathOperator = 'mathOperator', // 17
+    QueryOperator = 'queryOperator', // 18
+    Command = 'command', // 19
+    Keyword = 'keyword', // 20
+    MaterializedView = 'materializedView', // 21
+    SchemaMember = 'schemaMember', // 22
+    SignatureParameter = 'signatureParameter', // 23
+    Option = 'option', // 24
 }
 
 export const tokenTypes = [

--- a/package/tests/integration/syntax-highlighting.spec.ts
+++ b/package/tests/integration/syntax-highlighting.spec.ts
@@ -6,6 +6,8 @@ import convert from 'color-convert';
 
 const query = `// Query to analyze storm events 
 StormEvents
+| extend [\`\`\`Multiline
+Column\`\`\`] = "test"
 | where State == "Custom State 1"
 | project StartTime, EndTime, Duration = datetime_diff('minute', EndTime, StartTime)
 | summarize TotalDuration = avg(Duration) by State
@@ -14,12 +16,12 @@ StormEvents
 const queryTokensToQueryParts = {
     [Token.Comment]: ['// Query to analyze storm events'],
     [Token.Table]: ['StormEvents'],
-    [Token.QueryOperator]: ['where', 'project', 'summarize', 'order'],
+    [Token.QueryOperator]: ['where', 'project', 'summarize', 'order', 'extend'],
     [Token.Column]: ['StartTime', 'EndTime', 'Duration', 'TotalDuration'],
     [Token.Function]: ['datetime_diff', 'avg'],
-    [Token.StringLiteral]: ['Custom State 1', 'minute'],
+    [Token.StringLiteral]: ['Custom State 1', 'minute', 'Multiline', 'Column', 'test', '```'],
     [Token.MathOperator]: ['=='],
-    [Token.Punctuation]: ['|', ',', '(', ')', '='],
+    [Token.Punctuation]: ['|', ',', '(', ')', '=', '[', ']'],
 };
 
 const themeNames = [ThemeName.light, ThemeName.dark];
@@ -71,6 +73,7 @@ function createAssertTextColor(page: Page) {
     return async (text: string, expectedColorInHex: string) => {
         const expectedColor = hexToRgb(expectedColorInHex);
         const elements = await page.getByText(text).all();
+
         if (elements.length === 0) {
             return expect(elements.length).not.toBe(0);
         }

--- a/package/tests/integration/syntax-highlighting.spec.ts
+++ b/package/tests/integration/syntax-highlighting.spec.ts
@@ -6,7 +6,8 @@ import convert from 'color-convert';
 
 const query = `// Query to analyze storm events 
 StormEvents
-| extend [\`\`\`Multiline
+| extend [\`\`\`Multi
+line
 Column\`\`\`] = "test"
 | where State == "Custom State 1"
 | project StartTime, EndTime, Duration = datetime_diff('minute', EndTime, StartTime)
@@ -19,7 +20,7 @@ const queryTokensToQueryParts = {
     [Token.QueryOperator]: ['where', 'project', 'summarize', 'order', 'extend'],
     [Token.Column]: ['StartTime', 'EndTime', 'Duration', 'TotalDuration'],
     [Token.Function]: ['datetime_diff', 'avg'],
-    [Token.StringLiteral]: ['Custom State 1', 'minute', 'Multiline', 'Column', 'test', '```'],
+    [Token.StringLiteral]: ['Custom State 1', 'minute', 'Multi', 'line', 'Column', 'test', '```'],
     [Token.MathOperator]: ['=='],
     [Token.Punctuation]: ['|', ',', '(', ')', '=', '[', ']'],
 };


### PR DESCRIPTION
## Support Multiline Bracketed Strings in Semantic Tokenization

### Summary
This PR updates the `semanticTokenMaker` function to handle bracketed string tokens that span multiple lines (e.g., `[```line1\nline2```]`).  
Previously, such cases caused incorrect or broken syntax highlighting.

### Changes
- Added logic to detect when a token exceeds the current line’s length.
- Split tokens that span across lines into two separate semantic tokens to preserve proper coloring.

### Before
![image](https://github.com/user-attachments/assets/c3c7df17-9b2c-4f23-8e17-0445b0ad392d)

### After
![image](https://github.com/user-attachments/assets/69d889c6-9b19-4884-b517-75e484b45781)

