### PR TITLE
wrap pasted date strings with date string wrapper

### DIFF
--- a/package/src/editorExtensions/dateStringWrapper.ts
+++ b/package/src/editorExtensions/dateStringWrapper.ts
@@ -1,0 +1,29 @@
+export function dateStringWrapper(editor: monaco.editor.ICodeEditor) {
+    editor.onDidPaste(async (event) => {
+        const pastedTextRange = event.range;
+        if (!pastedTextRange) {
+            return;
+        }
+        const model = editor.getModel();
+        const pastedTextString = model.getValueInRange(pastedTextRange);
+        if (isBareUtcDate(pastedTextString)) {
+            const selection = editor.getSelection();
+            const startPos = selection?.getStartPosition();
+            if (model && startPos) {
+                const editOperation = {
+                    range: pastedTextRange,
+                    text: `datetime(${pastedTextString})`,
+                    forceMoveMarkers: true,
+                };
+                model.pushStackElement();
+                editor.executeEdits('paste-date', [editOperation], []);
+                model.pushStackElement();
+            }
+        }
+    });
+}
+
+function isBareUtcDate(text: string): boolean {
+    const s = text.trim();
+    return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(s);
+}

--- a/package/src/editorExtensions/dateStringWrapper.ts
+++ b/package/src/editorExtensions/dateStringWrapper.ts
@@ -6,7 +6,7 @@ export function dateStringWrapper(editor: monaco.editor.ICodeEditor) {
         }
         const model = editor.getModel();
         const pastedTextString = model.getValueInRange(pastedTextRange);
-        if (isBareUtcDate(pastedTextString)) {
+        if (isBareIsoDate(pastedTextString)) {
             const selection = editor.getSelection();
             const startPos = selection?.getStartPosition();
             if (model && startPos) {
@@ -23,7 +23,7 @@ export function dateStringWrapper(editor: monaco.editor.ICodeEditor) {
     });
 }
 
-function isBareUtcDate(text: string): boolean {
+export function isBareIsoDate(text: string): boolean {
     const s = text.trim();
-    return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(s);
+    return /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}Z)?$/.test(s);
 }

--- a/package/src/monaco.contribution.ts
+++ b/package/src/monaco.contribution.ts
@@ -3,6 +3,7 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import type * as mode from './kustoMode';
 import KustoCommandHighlighter from './editorExtensions/commandHighlighter';
 import KustoCommandFormatter from './editorExtensions/commandFormatter';
+import { dateStringWrapper } from './editorExtensions/dateStringWrapper';
 import { extend } from './extendedEditor';
 import type { LanguageServiceDefaults, WorkerAccessor } from './types';
 import type { LanguageSettings } from './languageServiceManager/settings';
@@ -129,6 +130,7 @@ monaco.editor.onDidCreateEditor((editor) => {
     }
 
     triggerSuggestDialogWhenCompletionItemSelected(editor);
+    dateStringWrapper(editor);
 });
 
 function triggerSuggestDialogWhenCompletionItemSelected(editor: monaco.editor.ICodeEditor) {

--- a/package/tests/integration/editor.spec.ts
+++ b/package/tests/integration/editor.spec.ts
@@ -46,5 +46,16 @@ test.describe('editor', () => {
             await page.keyboard.press('ArrowLeft');
             await expect(bracketElements).toHaveCount(2);
         });
+
+        test('wrap pasted datetime strings with datetime()', async ({ page }) => {
+            await page.evaluate(() => {
+                navigator.clipboard.writeText('2023-01-01T00:00:00Z');
+            });
+
+            await page.keyboard.press('ControlOrMeta+V');
+
+            const editorValue = model.editor().textContent().locator;
+            await expect(editorValue).toHaveText('datetime(2023-01-01T00:00:00Z)');
+        });
     });
 });

--- a/package/tests/integration/editor.spec.ts
+++ b/package/tests/integration/editor.spec.ts
@@ -47,7 +47,7 @@ test.describe('editor', () => {
             await expect(bracketElements).toHaveCount(2);
         });
 
-        test('wrap pasted datetime strings with datetime()', async ({ page }) => {
+        test('wrap pasted extended datetime strings with datetime()', async ({ page }) => {
             await page.evaluate(() => {
                 navigator.clipboard.writeText('2023-01-01T00:00:00Z');
             });
@@ -56,6 +56,17 @@ test.describe('editor', () => {
 
             const editorValue = model.editor().textContent().locator;
             await expect(editorValue).toHaveText('datetime(2023-01-01T00:00:00Z)');
+        });
+
+        test('wrap pasted date only strings with datetime()', async ({ page }) => {
+            await page.evaluate(() => {
+                navigator.clipboard.writeText('2023-01-01');
+            });
+
+            await page.keyboard.press('ControlOrMeta+V');
+
+            const editorValue = model.editor().textContent().locator;
+            await expect(editorValue).toHaveText('datetime(2023-01-01)');
         });
     });
 });

--- a/package/tests/integration/playwright.config.ts
+++ b/package/tests/integration/playwright.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     use: {
         trace: 'retain-on-failure',
         defaultBrowserType: 'chromium',
+        permissions: ['clipboard-read', 'clipboard-write'],
     },
     webServer: {
         command: 'yarn vite serve . --config ./vite.config.ts',

--- a/package/tests/integration/testkit/monakusto.model.ts
+++ b/package/tests/integration/testkit/monakusto.model.ts
@@ -32,6 +32,9 @@ export const createMonaKustoModel = (page: Page) => {
                 const button = page.locator(`#${theme}`);
                 await button.click();
             },
+            textContent: (editorTextContentLocator = page.locator('.view-lines.monaco-mouse-cursor-text')) => ({
+                locator: editorTextContentLocator,
+            }),
         }),
         settings: () => ({
             locator: page.locator('#settings'),


### PR DESCRIPTION
## Wrap pasted bare ISO **date** and **datetime** strings with `datetime()`

```kusto
// paste `2023-01-01T00:00:00Z`
--> datetime(2023-01-01T00:00:00Z)

// paste `2023-01-01`
--> datetime(2023-01-01)
