### PR TITLE
change query operator color

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Every PR should come with a test that checks it.
 
 ## Changelog
 
+## 13.1.1
+
+-   fix: Update query operator color to adhere to accessibility standards.
+
 ## 13.1.0
 
 -   feat: Add keyboard shortcuts for changing case:

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "13.1.0",
+    "version": "13.1.1",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/syntaxHighlighting/themes.ts
+++ b/package/src/syntaxHighlighting/themes.ts
@@ -17,7 +17,7 @@ const colors = {
     paleChestnut: '#D69D85',
     paleVioletRed: '#DB7093',
     firebrick: '#B22222',
-    orangeRed: '#FF4500',
+    orangeRed: '#CE3600',
     mediumVioletRed: '#C71585',
     magenta: '#FF00FF', // for debugging
     darkOrchid: '#9932CC',


### PR DESCRIPTION
### Update Query Operator Color for Accessibility

This PR updates the color used for query operators from `#FF4500` to `#CE3600`.

