### PR TITLE
support graph schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ This section provides a high-level overview of the main files and their responsi
 
 ## Changelog
 
+### 14.1.0
+
+-   feat: support graph schema
+
 ### 14.0.1
 
 -   chore: Update @kusto/language-service-next upgrade to 12.2.0

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ To run monaco-kusto locally inside the Azure-Kusto-WebUX project (which should e
 
 There are two ways to run the script:
 
-- **KustoWeb (default):** The script is currently set up to run the `kustoweb` app inside Azure-Kusto-WebUX. This is the default behavior.
-- **Fabric:** To run the Fabric app instead, simply comment out the Step 4 section for KustoWeb and uncomment the Step 4 section for Fabric in `debug-monaco-kusto.sh`.
+-   **KustoWeb (default):** The script is currently set up to run the `kustoweb` app inside Azure-Kusto-WebUX. This is the default behavior.
+-   **Fabric:** To run the Fabric app instead, simply comment out the Step 4 section for KustoWeb and uncomment the Step 4 section for Fabric in `debug-monaco-kusto.sh`.
 
 This allows you to easily switch between running KustoWeb and Fabric for local development.
 
@@ -147,24 +147,24 @@ This section provides a high-level overview of the main files and their responsi
 
 ![img.png](img.png)
 
-- **`monaco.contribution`**  
-  Declares and exports the Kusto language as a Monaco Editor contribution, making it available for registration and use externally.
+-   **`monaco.contribution`**  
+    Declares and exports the Kusto language as a Monaco Editor contribution, making it available for registration and use externally.
 
-- **`kustoMode`** Sets up and registers the Kusto language in Monaco Editor, wiring together language features, workers, and configuration.
+-   **`kustoMode`** Sets up and registers the Kusto language in Monaco Editor, wiring together language features, workers, and configuration.
 
-- **`workerManager`** Manages the lifecycle and communication with web workers that run language services in the background.
+-   **`workerManager`** Manages the lifecycle and communication with web workers that run language services in the background.
 
-- **`kustoWorker`** Implements the actual worker logic, handling requests for language features from the main thread.
+-   **`kustoWorker`** Implements the actual worker logic, handling requests for language features from the main thread.
 
-- **`kustoLanguageService`**  
-  Implements the core logic for Kusto language features such as parsing, validation, and providing language intelligence (completion, diagnostics, etc.).  
-  Uses the `language-service-next` library, which was originally created in C# and migrated to TypeScript using bridgejs.
+-   **`kustoLanguageService`**  
+    Implements the core logic for Kusto language features such as parsing, validation, and providing language intelligence (completion, diagnostics, etc.).  
+    Uses the `language-service-next` library, which was originally created in C# and migrated to TypeScript using bridgejs.
 
-- **`languageFeatures`**  
-  Contains adapters and implementations for Monaco Editor language features (completion, hover, formatting, folding, etc.) specific to Kusto.
+-   **`languageFeatures`**  
+    Contains adapters and implementations for Monaco Editor language features (completion, hover, formatting, folding, etc.) specific to Kusto.
 
-- **`monacoInstance`**  
-  Represents the Monaco Editor instance itself. It is responsible for editor creation, configuration, and interaction with the registered Kusto language features.
+-   **`monacoInstance`**  
+    Represents the Monaco Editor instance itself. It is responsible for editor creation, configuration, and interaction with the registered Kusto language features.
 
 ## Changelog
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "14.0.1",
+    "version": "14.1.0",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/languageServiceManager/kustoLanguageService.ts
+++ b/package/src/languageServiceManager/kustoLanguageService.ts
@@ -2259,7 +2259,8 @@ class KustoLanguageService implements LanguageService {
     private static createGraphModelSymbol(graph: s.Graph): sym.GraphModelSymbol {
         const edges = new Bridge.ArrayEnumerable(graph.edges || []);
         const nodes = new Bridge.ArrayEnumerable(graph.nodes || []);
-        return new sym.GraphModelSymbol.$ctor1(graph.name, edges, nodes, null);
+        const snapshots = new Bridge.ArrayEnumerable(graph.snapshots || []);
+        return new sym.GraphModelSymbol.$ctor1(graph.name, edges, nodes, snapshots );
     }
 }
 

--- a/package/src/languageServiceManager/kustoLanguageService.ts
+++ b/package/src/languageServiceManager/kustoLanguageService.ts
@@ -16,13 +16,7 @@ import k2 = Kusto.Language.Editor;
 import sym = Kusto.Language.Symbols;
 import GlobalState = Kusto.Language.GlobalState;
 
-import {
-    Database,
-    EntityGroup,
-    getCslTypeNameFromClrType,
-    getEntityDataTypeFromCslType,
-    showSchema,
-} from './schema';
+import { Database, EntityGroup, getCslTypeNameFromClrType, getEntityDataTypeFromCslType, showSchema } from './schema';
 import type { RenderOptions, VisualizationType, RenderOptionKeys, RenderInfo } from './renderInfo';
 import type { ClusterReference, DatabaseReference, GetReferencedGlobalParamsResult } from '../types';
 import { Mutable } from '../util';
@@ -939,7 +933,7 @@ class KustoLanguageService implements LanguageService {
                     EntityGroups = {},
                     MinorVersion,
                     MajorVersion,
-                    Graphs
+                    Graphs,
                 }: s.showSchema.Database) => ({
                     name: Name,
                     alternateName: databaseInContextAlternateName,
@@ -1003,8 +997,8 @@ class KustoLanguageService implements LanguageService {
                             edges: graph.Edges,
                             nodes: graph.Nodes,
                             snapshots: [],
-                        }
-                        return [...graphArray, graphEntity]
+                        };
+                        return [...graphArray, graphEntity];
                     }, []), // this is a temporary workaround as graphs are not included in the .show schema as json command output
                 })
             );
@@ -2263,9 +2257,9 @@ class KustoLanguageService implements LanguageService {
     }
 
     private static createGraphModelSymbol(graph: s.Graph): sym.GraphModelSymbol {
-        const edges =  new Bridge.ArrayEnumerable(graph.edges || []);
-        const nodes =  new Bridge.ArrayEnumerable(graph.nodes || []);
-        return new sym.GraphModelSymbol.$ctor1(graph.name, edges, nodes, null)
+        const edges = new Bridge.ArrayEnumerable(graph.edges || []);
+        const nodes = new Bridge.ArrayEnumerable(graph.nodes || []);
+        return new sym.GraphModelSymbol.$ctor1(graph.name, edges, nodes, null);
     }
 }
 

--- a/package/src/languageServiceManager/kustoLanguageService.ts
+++ b/package/src/languageServiceManager/kustoLanguageService.ts
@@ -2260,7 +2260,7 @@ class KustoLanguageService implements LanguageService {
         const edges = new Bridge.ArrayEnumerable(graph.edges || []);
         const nodes = new Bridge.ArrayEnumerable(graph.nodes || []);
         const snapshots = new Bridge.ArrayEnumerable(graph.snapshots || []);
-        return new sym.GraphModelSymbol.$ctor1(graph.name, edges, nodes, snapshots );
+        return new sym.GraphModelSymbol.$ctor1(graph.name, edges, nodes, snapshots);
     }
 }
 

--- a/package/src/languageServiceManager/kustoLanguageService.ts
+++ b/package/src/languageServiceManager/kustoLanguageService.ts
@@ -996,7 +996,7 @@ class KustoLanguageService implements LanguageService {
                             entityType: 'Graph',
                             edges: graph.Edges,
                             nodes: graph.Nodes,
-                            snapshots: [],
+                            snapshots: graph.Snapshots,
                         };
                         return [...graphArray, graphEntity];
                     }, []), // this is a temporary workaround as graphs are not included in the .show schema as json command output

--- a/package/src/languageServiceManager/kustoLanguageService.ts
+++ b/package/src/languageServiceManager/kustoLanguageService.ts
@@ -16,7 +16,7 @@ import k2 = Kusto.Language.Editor;
 import sym = Kusto.Language.Symbols;
 import GlobalState = Kusto.Language.GlobalState;
 
-import { Database, getCslTypeNameFromClrType, getEntityDataTypeFromCslType } from './schema';
+import { Database, EntityGroup, getCslTypeNameFromClrType, getEntityDataTypeFromCslType } from './schema';
 import type { RenderOptions, VisualizationType, RenderOptionKeys, RenderInfo } from './renderInfo';
 import type { ClusterReference, DatabaseReference, GetReferencedGlobalParamsResult } from '../types';
 import { Mutable } from '../util';

--- a/package/src/languageServiceManager/kustoLanguageService.ts
+++ b/package/src/languageServiceManager/kustoLanguageService.ts
@@ -16,7 +16,7 @@ import k2 = Kusto.Language.Editor;
 import sym = Kusto.Language.Symbols;
 import GlobalState = Kusto.Language.GlobalState;
 
-import { Database, EntityGroup, getCslTypeNameFromClrType, getEntityDataTypeFromCslType, showSchema } from './schema';
+import { Database, getCslTypeNameFromClrType, getEntityDataTypeFromCslType } from './schema';
 import type { RenderOptions, VisualizationType, RenderOptionKeys, RenderInfo } from './renderInfo';
 import type { ClusterReference, DatabaseReference, GetReferencedGlobalParamsResult } from '../types';
 import { Mutable } from '../util';
@@ -990,7 +990,7 @@ class KustoLanguageService implements LanguageService {
                                     : (inputParam.Columns as undefined | null | []),
                             })),
                         })),
-                    graphs: Object.values(Graphs).reduce((graphArray, graph: showSchema.Graph) => {
+                    graphs: Object.values(Graphs).reduce((graphArray, graph: s.showSchema.Graph) => {
                         const graphEntity = {
                             name: graph.Name,
                             entityType: 'Graph',

--- a/package/src/languageServiceManager/kustoLanguageService.ts
+++ b/package/src/languageServiceManager/kustoLanguageService.ts
@@ -989,6 +989,7 @@ class KustoLanguageService implements LanguageService {
                                     : (inputParam.Columns as undefined | null | []),
                             })),
                         })),
+                    graphs: [] // this is a temporary workaround as graphs are not included in the .show schema as json command output
                 })
             );
 
@@ -1761,10 +1762,11 @@ class KustoLanguageService implements LanguageService {
         const tableSymbols: sym.Symbol[] = (db.tables || []).map(this.createTableSymbol);
         const functionSymbols = (db.functions || []).map(this.createFunctionSymbol);
         const entityGroupsSymbols = (db.entityGroups || []).map(this.createEntityGroupSymbol);
+        const graphModelSymbols = (db.graphs || []).map(this.createGraphModelSymbol);
         const databaseSymbol = new sym.DatabaseSymbol.$ctor2(
             db.name,
             db.alternateName || null,
-            tableSymbols.concat(functionSymbols).concat(entityGroupsSymbols)
+            tableSymbols.concat(functionSymbols).concat(entityGroupsSymbols).concat(graphModelSymbols)
         );
 
         return databaseSymbol;
@@ -2242,6 +2244,10 @@ class KustoLanguageService implements LanguageService {
 
     private static createEntityGroupSymbol(entityGroup: s.EntityGroup): sym.EntityGroupSymbol {
         return new sym.EntityGroupSymbol.$ctor3(entityGroup.name, entityGroup.members.join(), null);
+    }
+
+    private static createGraphModelSymbol(graph: s.Graph): sym.GraphModelSymbol {
+        return new sym.GraphModelSymbol.$ctor1(graph.name, null, null, null)
     }
 }
 

--- a/package/src/languageServiceManager/schema.ts
+++ b/package/src/languageServiceManager/schema.ts
@@ -232,6 +232,7 @@ export namespace showSchema {
         readonly Name: string;
         readonly Nodes: string[];
         readonly Edges: string[];
+        readonly Snapshots: string[];
     }
 
     export interface Graphs {

--- a/package/src/languageServiceManager/schema.ts
+++ b/package/src/languageServiceManager/schema.ts
@@ -59,9 +59,14 @@ export interface Database {
     readonly alternateName?: string;
     readonly tables: readonly Table[];
     readonly functions: readonly Function[];
+    readonly graphs: readonly Graph[];
     readonly entityGroups: readonly EntityGroup[];
     readonly majorVersion: number;
     readonly minorVersion: number;
+}
+
+export interface Graph {
+    readonly name: string;
 }
 
 export type ClusterType = 'Engine' | 'DataManagement' | 'ClusterManager';

--- a/package/src/languageServiceManager/schema.ts
+++ b/package/src/languageServiceManager/schema.ts
@@ -67,6 +67,10 @@ export interface Database {
 
 export interface Graph {
     readonly name: string;
+    readonly entityType: 'Graph';
+    readonly edges: string[];
+    readonly nodes: string[];
+    readonly snapshots: string[];
 }
 
 export type ClusterType = 'Engine' | 'DataManagement' | 'ClusterManager';
@@ -224,6 +228,16 @@ export namespace showSchema {
         readonly [functionName: string]: Function;
     }
 
+    export interface Graph {
+        readonly Name: string;
+        readonly Nodes: string[];
+        readonly Edges: string[];
+    }
+
+    export interface Graphs {
+        readonly [graphName: string]: Graph;
+    }
+
     export interface Database {
         readonly Name: string;
         readonly Tables: Tables;
@@ -233,6 +247,7 @@ export namespace showSchema {
         readonly MajorVersion: number;
         readonly MinorVersion: number;
         readonly Functions: Functions;
+        readonly Graphs: Graphs;
         readonly DatabaseAccessMode: string;
     }
 

--- a/package/tests/integration/completion-items.spec.ts
+++ b/package/tests/integration/completion-items.spec.ts
@@ -80,7 +80,7 @@ test.describe('completion items', () => {
         await model.intellisense().waitForFocused();
 
         const focusedItem = model.intellisense().focused();
-        expect(focusedItem.locator).toHaveText('timespan()');
+        await expect(focusedItem.locator).toHaveText('timespan()');
     });
 
     test('Intellisense should remain open when typing "project-re"', async ({ page }) => {

--- a/package/tests/integration/editor.spec.ts
+++ b/package/tests/integration/editor.spec.ts
@@ -97,4 +97,37 @@ test.describe('editor', () => {
             await expect(editorValue).toContainText('storm events| where (datetime() < ago(1h))');
         });
     });
+
+    test.describe('schema validation', () => {
+        test('graph schema works', async ({ page }) => {
+            await page.keyboard.type("graph('Simple')\n");
+
+            // test node1 completion
+            await page.keyboard.type("| graph-match (node1)-[edge]->(node2)\n    where node1.");
+            await model.intellisense().wait()
+            const nodeOptions = await model.intellisense().options().locator.allInnerTexts();
+            expect(nodeOptions).toEqual([
+                'id',
+                'lbl',
+                'name',
+                'properties'
+            ]);
+
+            // test edge completion
+            await page.keyboard.type('name == "bli" and edge.');
+            await model.intellisense().wait()
+            const edgeOptions = await model.intellisense().options().locator.allInnerTexts();
+            expect(edgeOptions).toEqual([
+                'lbl',
+                'since',
+                'source',
+                'target'
+            ]);
+
+            // test entire query including graph name
+            await page.keyboard.type('lbl == "bla"\nproject node_column = node1.name, edge_column = edge.lbl');
+            await model.intellisense().wait() // just to ensure the query is fully parsed
+            await expect.poll(model.editor().hasErrors).toBeFalsy();
+        });
+    });
 });

--- a/package/tests/integration/editor.spec.ts
+++ b/package/tests/integration/editor.spec.ts
@@ -103,30 +103,20 @@ test.describe('editor', () => {
             await page.keyboard.type("graph('Simple')\n");
 
             // test node1 completion
-            await page.keyboard.type("| graph-match (node1)-[edge]->(node2)\n    where node1.");
-            await model.intellisense().wait()
+            await page.keyboard.type('| graph-match (node1)-[edge]->(node2)\n    where node1.');
+            await model.intellisense().wait();
             const nodeOptions = await model.intellisense().options().locator.allInnerTexts();
-            expect(nodeOptions).toEqual([
-                'id',
-                'lbl',
-                'name',
-                'properties'
-            ]);
+            expect(nodeOptions).toEqual(['id', 'lbl', 'name', 'properties']);
 
             // test edge completion
             await page.keyboard.type('name == "bli" and edge.');
-            await model.intellisense().wait()
+            await model.intellisense().wait();
             const edgeOptions = await model.intellisense().options().locator.allInnerTexts();
-            expect(edgeOptions).toEqual([
-                'lbl',
-                'since',
-                'source',
-                'target'
-            ]);
+            expect(edgeOptions).toEqual(['lbl', 'since', 'source', 'target']);
 
             // test entire query including graph name
             await page.keyboard.type('lbl == "bla"\nproject node_column = node1.name, edge_column = edge.lbl');
-            await model.intellisense().wait() // just to ensure the query is fully parsed
+            await model.intellisense().wait(); // just to ensure the query is fully parsed
             await expect.poll(model.editor().hasErrors).toBeFalsy();
         });
     });

--- a/package/tests/integration/env/main.ts
+++ b/package/tests/integration/env/main.ts
@@ -23,6 +23,10 @@ window.MonacoEnvironment = {
     },
 };
 
+interface TestableMonacoEditorElement extends HTMLElement {
+    __containerRef: monaco.editor.IStandaloneCodeEditor;
+}
+
 const schema = {
     Plugins: [],
     Databases: {
@@ -64,6 +68,62 @@ const schema = {
                         },
                     ],
                 },
+                SimpleGraph_Edges: {
+                    Name: 'SimpleGraph_Edges',
+                    Folder: 'Graph/Simple',
+                    DocString:
+                        'Represents a relationship table capturing interactions between entities such as people, companies, and cities.',
+                    OrderedColumns: [
+                        {
+                            Name: 'source',
+                            Type: 'System.String',
+                            CslType: 'string',
+                        },
+                        {
+                            Name: 'target',
+                            Type: 'System.String',
+                            CslType: 'string',
+                        },
+                        {
+                            Name: 'lbl',
+                            Type: 'System.String',
+                            CslType: 'string',
+                        },
+                        {
+                            Name: 'since',
+                            Type: 'System.String',
+                            CslType: 'string',
+                        },
+                    ],
+                },
+                SimpleGraph_Nodes: {
+                    Name: 'SimpleGraph_Nodes',
+                    Folder: 'Graph/Simple',
+                    DocString:
+                        'Represents a nodes table including people, companies, and cities, with associated metadata.',
+                    OrderedColumns: [
+                        {
+                            Name: 'id',
+                            Type: 'System.String',
+                            CslType: 'string',
+                        },
+                        {
+                            Name: 'lbl',
+                            Type: 'System.String',
+                            CslType: 'string',
+                        },
+                        {
+                            Name: 'name',
+                            Type: 'System.String',
+                            CslType: 'string',
+                        },
+                        {
+                            Name: 'properties',
+                            Type: 'System.Object',
+                            CslType: 'dynamic',
+                        },
+                    ],
+                },
             },
             Functions: {
                 MyFunc: {
@@ -76,6 +136,15 @@ const schema = {
                     OutputColumns: [],
                 },
             },
+            Graphs: {
+                Simple: {
+                    Name: 'Simple',
+                    EntityType: 'Graph',
+                    Nodes: ['SimpleGraph_Nodes'],
+                    Edges: ['SimpleGraph_Edges'],
+                    Snapshots: [],
+                },
+            },
         },
     },
 };
@@ -86,7 +155,8 @@ function getEditorValue(): string {
     return storageValue?.trim().length ? storageValue : defaultValue;
 }
 
-const editor = monaco.editor.create(document.getElementById('editor'), {
+const container = document.getElementById('editor')
+const editor = monaco.editor.create(container, {
     value: getEditorValue(),
     language: 'kusto',
     theme: 'kusto-light',
@@ -102,6 +172,7 @@ const editor = monaco.editor.create(document.getElementById('editor'), {
     copyWithSyntaxHighlighting: true,
     'semanticHighlighting.enabled': true,
 });
+(container as TestableMonacoEditorElement).__containerRef = editor;
 
 const updateEditorValueInLocalStorage = () => localStorage.setItem('dev-kusto-query', editor.getValue());
 const debouncedUpdateEditorValueInLocalStorage = debounce(updateEditorValueInLocalStorage, 1000);

--- a/package/tests/integration/env/main.ts
+++ b/package/tests/integration/env/main.ts
@@ -155,7 +155,7 @@ function getEditorValue(): string {
     return storageValue?.trim().length ? storageValue : defaultValue;
 }
 
-const container = document.getElementById('editor')
+const container = document.getElementById('editor');
 const editor = monaco.editor.create(container, {
     value: getEditorValue(),
     language: 'kusto',

--- a/package/tests/integration/index.html
+++ b/package/tests/integration/index.html
@@ -10,7 +10,7 @@
         <script type="module" src="/env/main.ts"></script>
         <h1>Monaco Kusto</h1>
         <div id="container">
-            <div id="editor"></div>
+            <div id="editor" data-testid="query-editor"></div>
             <div id="settings">
                 <h2>Settings</h2>
                 <label onclick="updateLanguageSettings(event)">


### PR DESCRIPTION
### Summary
Add support for **Graph Schema** integration.

### Changes
- Parse the graph array received from the application (MobX type) into a `GraphModelSymbol`.
- Add an **integration test** that validates both Intellisense completion items and error decorations in the query editor.
- Normalize test data from JSON results to entity results, since tests rely on JSON output.
- **Bump package version**.
