### PR TITLE
chore: bump CI Node.js version to 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
 
       - name: yarn install

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
 
       - name: yarn install

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ This section provides a high-level overview of the main files and their responsi
 
 ## Changelog
 
+### 14.2.1
+
+-   chore: bump CI Node.js version to 22
+
 ### 14.2.0
 
 -   feat: add `onSchemaUpdateComplete` event emitter so consumers can react to schema refresh completion

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "14.2.0",
+    "version": "14.2.1",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"


### PR DESCRIPTION
## Summary

Bump the Node.js version used by GitHub Actions CI (`main.yml` and `pr.yml`) from 20 to 22.

## Change type

patch — CI/build-only change with no public API surface modifications, per `.github/skills/semver-classification.skill.md` (PATCH: "Docs/build/deps bumps with no API surface change").

## Changes

-   .github/workflows/main.yml — `actions/setup-node` `node-version: 20` → `22`
-   .github/workflows/pr.yml — `actions/setup-node` `node-version: 20` → `22`
-   package/package.json — version bump `14.2.0` → `14.2.1`
-   README.md — add `14.2.1` changelog entry

## Breaking changes

_N/A_

## Tests added/modified in this PR:

_N/A_ — relies on existing CI suite running on Node 22 to validate the upgrade.

## Reviewer guidance

Confirm Node 22 is acceptable for the project's supported runtimes and that the existing CI jobs pass on the new version.
