### PR TITLE
User/netaringer/add references

### DIFF
--- a/.github/skills/semver-classification.skill.md
+++ b/.github/skills/semver-classification.skill.md
@@ -34,3 +34,9 @@ Highest priority wins. If uncertain between two levels, pick the higher one and 
 -   `git diff $BASE..HEAD -- package/src/**` for public surface changes
 -   `git log $BASE..HEAD` for conventional-commit prefixes and `BREAKING CHANGE` trailers
 -   `package/package.json` (current version) and `CHANGELOG.md` (prior style)
+
+## References
+
+-   [Semantic Versioning 2.0.0 specification](https://semver.org/)
+-   [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
+-   [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ This section provides a high-level overview of the main files and their responsi
 
 ## Changelog
 
+### 14.2.2
+
+-   docs: add external references to semver-classification skill
+
 ### 14.2.1
 
 -   chore: bump CI Node.js version to 22

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "14.2.1",
+    "version": "14.2.2",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"


### PR DESCRIPTION
## Summary

Adds a References section to `.github/skills/semver-classification.skill.md` with links to
the SemVer 2.0.0 spec, Conventional Commits spec, and Keep a Changelog guide — making the
skill self-contained for anyone applying it.

## Change type

patch — docs-only change to an internal skill file; no public API surface modified
(per `.github/skills/semver-classification.skill.md` PATCH rules: "Docs/build/deps bumps with no API surface change").

## Changes

-   `.github/skills/semver-classification.skill.md` — appended a `## References` section with three external links
