### PR TITLE
fix: update darkOrchid syntax highlighting color to #8229AD

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ This section provides a high-level overview of the main files and their responsi
 
 ## Changelog
 
+### 14.2.3
+
+-   fix: update `darkOrchid` syntax highlighting color to `#8229AD`
+
 ### 14.2.2
 
 -   docs: add external references to semver-classification skill

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kusto/monaco-kusto",
-    "version": "14.2.2",
+    "version": "14.2.3",
     "description": "CSL, KQL plugin for the Monaco Editor",
     "author": {
         "name": "Microsoft"

--- a/package/src/syntaxHighlighting/themes.ts
+++ b/package/src/syntaxHighlighting/themes.ts
@@ -20,7 +20,7 @@ const colors = {
     orangeRed: '#CE3600',
     mediumVioletRed: '#C71585',
     magenta: '#FF00FF', // for debugging
-    darkOrchid: '#9932CC',
+    darkOrchid: '#8229AD',
     darkViolet: '#9400D3',
     midnightBlue: '#191970',
     blue: '#0000FF',


### PR DESCRIPTION
### Summary

 <!--

 Link to the issue describing the bug that you're fixing.

 Provide a general description of the code changes in your pull request.

 -->

### Other Information

 <!--

 If there's anything else that's important and relevant to your pull request, mention that information here.

 -->
